### PR TITLE
UI polish: primary headings, outline icons, DaisyUI Appearance dropdown, reorder UX tweaks

### DIFF
--- a/census_app/core/templates/core/profile.html
+++ b/census_app/core/templates/core/profile.html
@@ -12,14 +12,26 @@
 {% endblock %}
 {% block content %}
 <div class="prose">
-  <h1>Your Profile</h1>
+  <h1 class="inline-flex items-center gap-2 text-primary">
+    {% include "components/icons/users.html" with classes="w-6 h-6 text-primary" %}
+    <span>Your Profile</span>
+  </h1>
   <p>Signed in as <strong>{{ request.user.username }}</strong></p>
+  {% if org %}
+  <h2 class="inline-flex items-center gap-2 text-primary mt-2">
+    {% include "components/icons/building.html" with classes="w-5 h-5 text-primary" %}
+    <span>Your organisation: {{ org.name }}</span>
+  </h2>
+  {% endif %}
 </div>
 
 <div class="mt-6 max-w-2xl">
   <div class="card bg-base-100 shadow mb-6">
     <div class="card-body">
-      <h2 class="card-title">Your badges</h2>
+      <h2 class="card-title inline-flex items-center gap-2 text-primary">
+        {% include "components/icons/users.html" with classes="w-5 h-5 text-primary" %}
+        <span>Your badges</span>
+      </h2>
       <div class="flex flex-wrap gap-2 items-center">
         {% if stats.is_superuser %}
           <span class="badge badge-primary">Superuser</span>
@@ -59,15 +71,24 @@
   </div>
   <div class="card bg-base-100 shadow mb-6">
     <div class="card-body">
-      <h2 class="card-title">Appearance</h2>
+      <h2 class="card-title inline-flex items-center gap-2 text-primary">
+        {% include "components/icons/bolt.html" with classes="w-5 h-5 text-primary" %}
+        <span>Appearance</span>
+      </h2>
       <p class="opacity-80">Choose your theme. This only affects your view and is saved in your browser.</p>
       <div class="form-control">
-        <label class="label" for="theme-select"><span class="label-text">Theme</span></label>
-        <select id="theme-select" class="select select-bordered w-full max-w-xs">
-          <option value="system">System</option>
-          <option value="census-light">Light</option>
-          <option value="census-dark">Dark</option>
-        </select>
+        <span class="label"><span class="label-text">Theme</span></span>
+        <div class="dropdown">
+          <div id="theme-dropdown-btn" tabindex="0" role="button" class="btn w-48 justify-between">
+            <span id="theme-current-label">System</span>
+            <!-- caret handled by button styles -->
+          </div>
+          <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-10 w-48 p-2 shadow">
+            <li><button type="button" data-theme-choice="system">System</button></li>
+            <li><button type="button" data-theme-choice="census-light">Light</button></li>
+            <li><button type="button" data-theme-choice="census-dark">Dark</button></li>
+          </ul>
+        </div>
         <noscript>
           <div class="alert alert-warning mt-3">Enable JavaScript to change theme.</div>
         </noscript>
@@ -78,7 +99,10 @@
   {% if request.user.is_superuser %}
   <div class="card bg-base-100 shadow mb-6">
     <div class="card-body">
-      <h2 class="card-title">Project theme and brand (admins)</h2>
+      <h2 class="card-title inline-flex items-center gap-2 text-primary">
+        {% include "components/icons/hammer_wrench.html" with classes="w-5 h-5 text-primary" %}
+        <span>Project theme and brand (admins)</span>
+      </h2>
       <p class="opacity-80">Paste DaisyUI Builder output (light and dark) to reskin the whole app. Fonts and icon apply globally.</p>
       <div class="flex items-center gap-3 mb-3 flex-wrap">
         <div class="flex items-center gap-2">
@@ -154,7 +178,10 @@
   {% if not can_manage_any_users %}
     <div class="card bg-base-100 shadow">
       <div class="card-body">
-        <h2 class="card-title">Upgrade to organisation</h2>
+        <h2 class="card-title inline-flex items-center gap-2 text-primary">
+          {% include "components/icons/building.html" with classes="w-5 h-5 text-primary" %}
+          <span>Upgrade to organisation</span>
+        </h2>
         <p class="opacity-80">Upgrading creates an organisation that you administer. You’ll be able to host surveys and build a team. Simple users cannot gain permissions inside someone else’s organisation, but you can create your own organisation at any time.</p>
         <form method="post" class="space-y-3">
           {% csrf_token %}

--- a/census_app/core/views.py
+++ b/census_app/core/views.py
@@ -74,6 +74,12 @@ def profile(request):
             sb = None
     # Lightweight stats for badges
     user = request.user
+    # Pick a primary organisation if present: prefer one the user owns; else first membership
+    primary_owned_org = Organization.objects.filter(owner=user).first()
+    first_membership = (
+        OrganizationMembership.objects.filter(user=user).select_related("organization").first()
+    )
+    org = primary_owned_org or (first_membership.organization if first_membership else None)
     stats = {
         "is_superuser": getattr(user, "is_superuser", False),
         "is_staff": getattr(user, "is_staff", False),
@@ -87,7 +93,7 @@ def profile(request):
         "responses_submitted": SurveyResponse.objects.filter(submitted_by=user).count(),
         "tokens_created": SurveyAccessToken.objects.filter(created_by=user).count(),
     }
-    return render(request, "core/profile.html", {"sb": sb, "stats": stats})
+    return render(request, "core/profile.html", {"sb": sb, "stats": stats, "org": org})
 
 
 def signup(request):

--- a/census_app/static/js/builder.js
+++ b/census_app/static/js/builder.js
@@ -34,19 +34,33 @@
         const ids = Array.from(el.querySelectorAll("[data-qid]")).map(
           (li) => li.dataset.qid
         );
-        const form = new FormData();
-        form.append("order", ids.join(","));
+        const body = new URLSearchParams({ order: ids.join(",") });
         fetch(
           el.dataset.reorderUrl ||
             window.location.pathname.replace(/\/$/, "") + "/questions/reorder",
           {
             method: "POST",
-            headers: { "X-CSRFToken": csrfToken() },
-            body: form,
+            headers: {
+              "Content-Type": "application/x-www-form-urlencoded",
+              "X-CSRFToken": csrfToken(),
+              "X-Requested-With": "XMLHttpRequest",
+            },
+            body,
           }
-        ).then(() => {
-          renumberQuestions(el);
-        });
+        )
+          .then((resp) => {
+            if (!resp.ok) {
+              console.error("Failed to persist question order", resp.status);
+              return;
+            }
+            renumberQuestions(el);
+            if (typeof window.showToast === "function") {
+              window.showToast("Order saved", "success");
+            }
+          })
+          .catch((err) => {
+            console.error("Error persisting question order", err);
+          });
       },
     });
   }

--- a/census_app/static/js/theme-toggle.js
+++ b/census_app/static/js/theme-toggle.js
@@ -2,6 +2,8 @@
   const KEY = "census-theme"; // values: 'system' | 'census-light' | 'census-dark'
   const htmlEl = document.documentElement;
   const select = document.getElementById("theme-select");
+  const ddBtn = document.getElementById("theme-dropdown-btn");
+  const ddLabel = document.getElementById("theme-current-label");
   const media = window.matchMedia("(prefers-color-scheme: dark)");
 
   function normalize(pref) {
@@ -47,11 +49,24 @@
     } catch (_) {}
   }
 
+  function labelFor(pref) {
+    switch (pref) {
+      case "census-light":
+        return "Light";
+      case "census-dark":
+        return "Dark";
+      case "system":
+      default:
+        return "System";
+    }
+  }
+
   function hydrate() {
     const saved = readSaved();
     if (saved) {
       applyTheme(saved);
       if (select) select.value = normalize(saved) || saved;
+      if (ddLabel) ddLabel.textContent = labelFor(saved);
       return saved;
     }
     // default to current server-set theme, but set select to 'system' if it matches OS
@@ -60,6 +75,11 @@
     const systemTheme = effectiveTheme("system");
     if (select) {
       select.value = current === systemTheme ? "system" : current;
+    }
+    if (ddLabel) {
+      ddLabel.textContent = labelFor(
+        current === systemTheme ? "system" : current
+      );
     }
     // apply current as-is (server default) without persisting
     applyTheme(current);
@@ -86,12 +106,79 @@
       media.addListener(onMediaChange);
     }
 
-    if (!select) return;
-    select.addEventListener("change", () => {
-      const pref = select.value; // 'system' | 'census-light' | 'census-dark'
-      applyTheme(pref);
-      persist(pref);
-    });
+    if (select) {
+      select.addEventListener("change", () => {
+        const pref = select.value; // 'system' | 'census-light' | 'census-dark'
+        applyTheme(pref);
+        persist(pref);
+        if (ddLabel) ddLabel.textContent = labelFor(pref);
+      });
+    }
+
+    // Dropdown menu handling (use event delegation and pointerdown for reliability)
+    if (ddBtn) {
+      const dd = ddBtn.closest(".dropdown");
+      const menu = dd ? dd.querySelector(".dropdown-content") : null;
+
+      function setTheme(pref) {
+        applyTheme(pref);
+        persist(pref);
+        if (ddLabel) ddLabel.textContent = labelFor(pref);
+        if (select) select.value = pref;
+        // update active marker
+        if (menu) {
+          menu
+            .querySelectorAll("li")
+            .forEach((li) => li.classList.remove("active"));
+          const targetBtn = menu.querySelector(`[data-theme-choice="${pref}"]`);
+          if (targetBtn) {
+            const li = targetBtn.closest("li");
+            if (li) li.classList.add("active");
+          }
+        }
+        // close dropdown by blurring the button (focus-based dropdown)
+        ddBtn.blur();
+      }
+
+      // hydrate active marker
+      const current =
+        readSaved() ||
+        normalize(htmlEl.getAttribute("data-theme")) ||
+        "census-light";
+      if (menu) {
+        const systemTheme = effectiveTheme("system");
+        const prefShown = current === systemTheme ? "system" : current;
+        menu
+          .querySelectorAll("li")
+          .forEach((li) => li.classList.remove("active"));
+        const activeBtn = menu.querySelector(
+          `[data-theme-choice="${prefShown}"]`
+        );
+        if (activeBtn) {
+          const li = activeBtn.closest("li");
+          if (li) li.classList.add("active");
+        }
+      }
+
+      if (menu) {
+        // Use pointerdown so the handler runs even if focus changes immediately
+        menu.addEventListener("pointerdown", (e) => {
+          const target = e.target.closest("[data-theme-choice]");
+          if (!target) return;
+          e.preventDefault();
+          const pref = target.getAttribute("data-theme-choice");
+          setTheme(pref);
+        });
+        // Fallback for click (some devices)
+        menu.addEventListener("click", (e) => {
+          const target = e.target.closest("[data-theme-choice]");
+          if (!target) return;
+          e.preventDefault();
+          const pref = target.getAttribute("data-theme-choice");
+          setTheme(pref);
+        });
+      }
+    }
   }
 
   if (document.readyState === "loading") {

--- a/census_app/static/js/toast.js
+++ b/census_app/static/js/toast.js
@@ -1,0 +1,98 @@
+(function () {
+  // mark when toast script is loaded (for quick console checks)
+  try {
+    window._toastLoaded = true;
+  } catch (e) {}
+  function ensureRoot() {
+    var root = document.getElementById("toast-root");
+    if (!root) {
+      root = document.createElement("div");
+      root.id = "toast-root";
+      root.className = "toast toast-top toast-end z-[1000]";
+      root.setAttribute("aria-live", "polite");
+      root.setAttribute("aria-atomic", "true");
+      // Inline fallback styles in case Tailwind/DaisyUI purges 'toast' classes
+      try {
+        root.style.position = "fixed";
+        root.style.top = "1rem";
+        root.style.right = "1rem";
+        root.style.display = "flex";
+        root.style.flexDirection = "column";
+        root.style.gap = "0.5rem";
+        root.style.zIndex = "999999"; // above sticky toolbars
+        root.style.pointerEvents = "none"; // let clicks pass except on alerts
+      } catch (e) {}
+      // Prefer to place near end of body to avoid layout interference
+      (document.body || document.documentElement).appendChild(root);
+    }
+    return root;
+  }
+
+  function makeToast(message, type) {
+    try {
+      var root = ensureRoot();
+      var colors = {
+        success: "alert-success",
+        info: "alert-info",
+        warning: "alert-warning",
+        error: "alert-error",
+      };
+      var cls = colors[type] || colors.info;
+      var wrap = document.createElement("div");
+      wrap.className = "alert " + cls + " shadow";
+      // Allow interactions on the alert itself
+      wrap.style.pointerEvents = "auto";
+      // Fallback minimal styling (visible even without DaisyUI)
+      try {
+        if (!wrap.style.backgroundColor) wrap.style.backgroundColor = "#1f2937"; // gray-800
+        if (!wrap.style.color) wrap.style.color = "#fff";
+        if (!wrap.style.padding) wrap.style.padding = "0.5rem 0.75rem";
+        if (!wrap.style.borderRadius) wrap.style.borderRadius = "0.5rem";
+        if (!wrap.style.boxShadow)
+          wrap.style.boxShadow = "0 2px 8px rgba(0,0,0,0.2)";
+      } catch (e) {}
+      // content
+      var span = document.createElement("span");
+      span.textContent = message;
+      wrap.appendChild(span);
+      // close button
+      var btn = document.createElement("button");
+      btn.setAttribute("type", "button");
+      btn.className = "btn btn-ghost btn-xs ml-2";
+      btn.setAttribute("aria-label", "Close");
+      btn.innerHTML = "&times;";
+      btn.addEventListener("click", function () {
+        dismiss(wrap);
+      });
+      wrap.appendChild(btn);
+      // insert
+      root.appendChild(wrap);
+      try {
+        console.debug("Toast appended:", message, type);
+      } catch (e) {}
+      // auto dismiss
+      setTimeout(function () {
+        dismiss(wrap);
+      }, 2000);
+    } catch (e) {
+      console && console.warn && console.warn("Toast error", e);
+    }
+  }
+  function dismiss(el) {
+    if (!el) return;
+    el.classList.add("transition", "duration-500");
+    el.style.opacity = "0";
+    setTimeout(function () {
+      if (el && el.parentElement) {
+        el.remove();
+      }
+    }, 500);
+  }
+  // expose globally
+  window.showToast = function (message, type) {
+    try {
+      console.debug("showToast:", message, type);
+    } catch (e) {}
+    makeToast(message, type || "info");
+  };
+})();

--- a/census_app/surveys/templates/surveys/builder.html
+++ b/census_app/surveys/templates/surveys/builder.html
@@ -33,7 +33,10 @@
     <div class="md:col-span-2">
       <div class="card bg-base-100 shadow">
         <div class="card-body">
-          <h2 class="card-title">All Questions</h2>
+          <h2 class="card-title inline-flex items-center gap-2 text-primary">
+            {% include "components/icons/document.html" with classes="w-5 h-5 text-primary" %}
+            <span>All Questions</span>
+          </h2>
           {% include 'surveys/partials/questions_list.html' %}
         </div>
       </div>

--- a/census_app/surveys/templates/surveys/group_builder.html
+++ b/census_app/surveys/templates/surveys/group_builder.html
@@ -6,8 +6,8 @@
   <div class="prose">
     {% include 'components/breadcrumbs.html' with  crumb1_label="Survey Dashboard"  crumb1_href="/surveys/"|add:survey.slug|add:"/dashboard/"  crumb2_label="Groups"  crumb2_href="/surveys/"|add:survey.slug|add:"/groups/"  crumb3_label="Manage Questions"  crumb3_href="/surveys/"|add:survey.slug|add:"/builder/groups/"|add:group.id|add:"/questions/" %}
     <h1 class="inline-flex items-center gap-2">
-      {% include "components/icons/documents.html" with classes="w-6 h-6" %}
-      <span>Manage Questions</span>
+      {% include "components/icons/documents.html" with classes="w-6 h-6 text-primary" %}
+      <span class="text-primary">Manage Questions</span>
     </h1>
     <h2 class="mt-0">Group: {{ group.name }}</h2>
     {% if group.description %}<p class="mt-0">{{ group.description }}</p>{% endif %}
@@ -28,8 +28,8 @@
       <div class="md:col-span-2">
         <div class="card bg-base-100 shadow">
           <div class="card-body">
-            <h2 class="card-title inline-flex items-center gap-2">
-              {% include "components/icons/document.html" with classes="w-5 h-5" %}
+            <h2 class="card-title inline-flex items-center gap-2 text-primary">
+              {% include "components/icons/document.html" with classes="w-5 h-5 text-primary" %}
               <span>Questions in this group</span>
             </h2>
             <div id="questions-list">
@@ -48,8 +48,8 @@
       <div>
         <div class="card bg-base-100 shadow">
           <div class="card-body">
-            <h2 class="card-title inline-flex items-center gap-2">
-              {% include "components/icons/document.html" with classes="w-5 h-5" %}
+            <h2 class="card-title inline-flex items-center gap-2 text-primary">
+              {% include "components/icons/document.html" with classes="w-5 h-5 text-primary" %}
               <span>Add Question</span>
             </h2>
             <form id="create-question-form" hx-post="/surveys/{{ survey.slug }}/builder/groups/{{ group.id }}/questions/create" hx-target="#questions-list" hx-swap="outerHTML">

--- a/census_app/surveys/templates/surveys/groups.html
+++ b/census_app/surveys/templates/surveys/groups.html
@@ -97,7 +97,6 @@
     </ul>
   <div class="flex flex-wrap gap-2 items-center sticky top-0 z-40 bg-base-200/95 backdrop-blur supports-[backdrop-filter]:bg-base-200/70 py-2">
   {% if can_edit %}
-  <button id="save-order-btn" class="btn btn-primary btn-sm" type="button" disabled>{% trans "Save order" %}</button>
   <button id="create-repeat-btn" class="btn btn-secondary btn-sm inline-flex items-center gap-2" type="button" disabled>
     {% include "components/icons/repeat.html" with classes="w-4 h-4" %}
     <span>{% trans "Create repeat from selection" %}</span>

--- a/census_app/surveys/templates/surveys/list.html
+++ b/census_app/surveys/templates/surveys/list.html
@@ -2,33 +2,41 @@
 {% load static %}
 {% block title %}Your Surveys - Census{% endblock %}
 {% block content %}
-<div class="prose">
+<div class="prose max-w-none">
+  {% include 'components/breadcrumbs.html' with crumb1_label='Surveys' crumb1_href='/surveys/' %}
   <h1 class="inline-flex items-center gap-2">
-    {% include "components/icons/clipboard.html" with classes="w-6 h-6" %}
-    <span>Your Surveys</span>
+    {% include "components/icons/clipboard.html" with classes="w-6 h-6 text-primary" %}
+    <span class="text-primary">Your Surveys</span>
   </h1>
   {% if user.is_authenticated %}
     <p><a class="btn btn-primary not-prose" href="/surveys/create/">Create survey</a></p>
   {% endif %}
   {% if surveys %}
-  <ul class="not-prose list bg-base-100 rounded-box shadow-md">
+  <ul class="not-prose w-full flex flex-col gap-3">
       {% for s in surveys %}
-  <li class="list-row w-full p-4 sm:p-5 flex flex-col gap-3">
-          <div class="flex items-center gap-4">
-            <div class="flex-shrink-0 inline-flex items-center justify-center">
-            {% include "components/icons/census_brand.html" with classes=brand.icon_size_class|default:'w-8 h-8' aria_label=brand.icon_alt|default:brand.title title=brand.icon_title|default:brand.title %}
+        <li class="w-full">
+          <div class="w-full bg-base-100 rounded-lg border border-base-300 p-3 sm:p-4 hover:border-primary transition-colors">
+            <div class="flex items-center gap-4 min-w-0">
+              <div class="flex-shrink-0 inline-flex items-center justify-center">
+                {% include "components/icons/census_brand.html" with classes=brand.icon_size_class|default:'w-8 h-8' aria_label=brand.icon_alt|default:brand.title title=brand.icon_title|default:brand.title %}
+              </div>
+              <div class="min-w-0 w-full">
+                <div class="flex items-center gap-2 min-w-0">
+                  <div class="font-medium leading-tight truncate">{{ s.name }}</div>
+                  <span class="badge badge-primary badge-outline whitespace-nowrap">{{ s.get_status_display|default:s.status }}</span>
+                </div>
+                {% if s.description %}
+                  <div class="text-sm opacity-70 truncate">{{ s.description }}</div>
+                {% endif %}
+              </div>
             </div>
-            <div class="min-w-0">
-              <div class="font-medium leading-tight">{{ s.name }}</div>
-              <div class="text-xs uppercase font-semibold opacity-60 truncate">{{ s.description }}</div>
-            </div>
-          </div>
-          <div class="-mx-1 overflow-x-auto">
-            <div class="px-1 min-w-max flex items-center gap-2">
-              <a class="btn btn-primary btn-sm" href="/surveys/{{ s.slug }}/dashboard/">Dashboard</a>
-              <a class="btn btn-primary btn-sm" href="/surveys/{{ s.slug }}/groups/">Groups</a>
-              <a class="btn btn-primary btn-sm" href="/surveys/{{ s.slug }}/preview/">Preview</a>
-              <a class="btn btn-primary btn-sm" href="/surveys/{{ s.slug }}/bulk-upload/">Import</a>
+            <div class="-mx-1 overflow-x-auto mt-3">
+              <div class="px-1 min-w-max flex items-center gap-2">
+                <a class="btn btn-primary btn-sm" href="/surveys/{{ s.slug }}/dashboard/">Dashboard</a>
+                <a class="btn btn-primary btn-sm" href="/surveys/{{ s.slug }}/groups/">Groups</a>
+                <a class="btn btn-primary btn-sm" href="/surveys/{{ s.slug }}/preview/">Preview</a>
+                <a class="btn btn-primary btn-sm" href="/surveys/{{ s.slug }}/bulk-upload/">Import</a>
+              </div>
             </div>
           </div>
         </li>

--- a/census_app/surveys/templates/surveys/org_users.html
+++ b/census_app/surveys/templates/surveys/org_users.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% block content %}
-<h1 class="text-2xl font-bold mb-4">Organisation users: {{ org.name }}</h1>
+<h1 class="text-2xl font-bold mb-4 inline-flex items-center gap-2 text-primary">
+  {% include "components/icons/users.html" with classes="w-6 h-6 text-primary" %}
+  <span>Organisation users: {{ org.name }}</span>
+</h1>
 <table class="table w-full mb-6">
   <thead><tr><th>User</th><th>Role</th><th>Actions</th></tr></thead>
   <tbody>
@@ -23,7 +26,10 @@
   </tbody>
 </table>
 
-<h2 class="text-xl font-semibold mb-2">Add or update user</h2>
+<h2 class="text-xl font-semibold mb-2 text-primary inline-flex items-center gap-2">
+  {% include "components/icons/users.html" with classes="w-5 h-5 text-primary" %}
+  <span>Add or update user</span>
+</h2>
 <form method="post" class="space-y-2">
   {% csrf_token %}
   <input type="hidden" name="action" value="add" />

--- a/census_app/surveys/templates/surveys/survey_users.html
+++ b/census_app/surveys/templates/surveys/survey_users.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% block content %}
-<h1 class="text-2xl font-bold mb-4">Survey users: {{ survey.name }}</h1>
+<h1 class="text-2xl font-bold mb-4 inline-flex items-center gap-2 text-primary">
+  {% include "components/icons/users.html" with classes="w-6 h-6 text-primary" %}
+  <span>Survey users: {{ survey.name }}</span>
+</h1>
 <table class="table w-full mb-6">
   <thead><tr><th>User</th><th>Role</th>{% if can_manage %}<th>Actions</th>{% endif %}</tr></thead>
   <tbody>
@@ -26,7 +29,10 @@
 </table>
 
 {% if can_manage %}
-<h2 class="text-xl font-semibold mb-2">Add or update user</h2>
+<h2 class="text-xl font-semibold mb-2 text-primary inline-flex items-center gap-2">
+  {% include "components/icons/users.html" with classes="w-5 h-5 text-primary" %}
+  <span>Add or update user</span>
+</h2>
 <form method="post" class="space-y-2">
   {% csrf_token %}
   <input type="hidden" name="action" value="add" />

--- a/census_app/surveys/templates/surveys/user_management_hub.html
+++ b/census_app/surveys/templates/surveys/user_management_hub.html
@@ -1,14 +1,20 @@
 {% extends "base.html" %}
 {% block title %}User management · {{ block.super }}{% endblock %}
 {% block content %}
-  <h1 class="text-2xl font-semibold mb-4">User management</h1>
+  <h1 class="text-2xl font-semibold mb-4 inline-flex items-center gap-2 text-primary">
+    {% include "components/icons/users.html" with classes="w-6 h-6 text-primary" %}
+    <span class="text-primary">User management</span>
+  </h1>
 
   {% if not org %}
     <div class="alert">You don't have an organisation to manage yet.</div>
   {% else %}
     <div class="card bg-base-100 shadow mb-6">
       <div class="card-body">
-        <h2 class="card-title">Organisation: {{ org.name }}</h2>
+        <h2 class="inline-flex items-center gap-2 font-semibold text-lg text-primary">
+          {% include "components/icons/users.html" with classes="w-5 h-5 text-primary" %}
+          <span class="text-primary">Organisation: {{ org.name }}</span>
+        </h2>
         <div class="mb-3">
           <form hx-post="{% url 'surveys:user_management_hub' %}" hx-target="#org-add-result" hx-swap="innerHTML" method="post" class="flex items-end gap-2">
             {% csrf_token %}
@@ -43,7 +49,10 @@
 
     <div class="card bg-base-100 shadow">
       <div class="card-body">
-        <h2 class="card-title">Users by survey</h2>
+        <h2 class="inline-flex items-center gap-2 font-semibold text-lg text-primary">
+          {% include "components/icons/users.html" with classes="w-5 h-5 text-primary" %}
+          <span class="text-primary">Users by survey</span>
+        </h2>
         <div class="mb-3">
           <form hx-post="{% url 'surveys:user_management_hub' %}" hx-target="#survey-add-result" hx-swap="innerHTML" method="post" class="flex items-end gap-2">
             {% csrf_token %}

--- a/census_app/templates/base.html
+++ b/census_app/templates/base.html
@@ -144,6 +144,9 @@
     </footer>
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
     <script src="{% static 'js/theme-toggle.js' %}"></script>
+    {# Global toast root for lightweight notifications #}
+    <div id="toast-root" class="toast toast-top toast-end z-[1000]" aria-live="polite" aria-atomic="true"></div>
+    <script src="{% static 'js/toast.js' %}?v={{ build.commit|default:build.timestamp }}"></script>
     {% block extra_js %}{% endblock %}
   </body>
   </html>

--- a/census_app/templates/components/icons/building.html
+++ b/census_app/templates/components/icons/building.html
@@ -1,0 +1,17 @@
+{% comment %} {# Building/organisation icon (outline). Usage: {% include "components/icons/building.html" with classes="w-5 h-5 text-primary" %} #} {% endcomment %}
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ classes|default:'w-5 h-5' }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+  <!-- Building body -->
+  <rect x="3" y="4" width="14" height="16" rx="2" ry="2"></rect>
+  <!-- Annex -->
+  <rect x="17" y="9" width="4" height="11" rx="1" ry="1"></rect>
+  <!-- Windows -->
+  <line x1="6" y1="7" x2="8" y2="7"></line>
+  <line x1="10" y1="7" x2="12" y2="7"></line>
+  <line x1="6" y1="10" x2="8" y2="10"></line>
+  <line x1="10" y1="10" x2="12" y2="10"></line>
+  <line x1="6" y1="13" x2="8" y2="13"></line>
+  <line x1="10" y1="13" x2="12" y2="13"></line>
+  <!-- Door -->
+  <rect x="9" y="16" width="4" height="4" rx="0.5" ry="0.5"></rect>
+  <title>Organisation</title>
+</svg>

--- a/census_app/templates/components/icons/clipboard.html
+++ b/census_app/templates/components/icons/clipboard.html
@@ -1,7 +1,7 @@
-{% comment %} {# Clipboard icon (survey). Usage: {% include "components/icons/clipboard.html" with classes="w-4 h-4" %} #} {% endcomment %}
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+{% comment %} {# Clipboard icon (survey). Usage: {% include "components/icons/clipboard.html" with classes="w-4 h-4 text-primary" %} #} {% endcomment %}
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ classes|default:'w-4 h-4' }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
   <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/>
-  <rect x="8" y="2" width="8" height="4" rx="1" ry="1" fill="black"/>
+  <rect x="8" y="2" width="8" height="4" rx="1" ry="1" fill="currentColor"/>
   <line x1="8" y1="8" x2="16" y2="8"/>
   <line x1="8" y1="12" x2="16" y2="12"/>
   <line x1="8" y1="16" x2="16" y2="16"/>

--- a/census_app/templates/components/icons/document.html
+++ b/census_app/templates/components/icons/document.html
@@ -1,4 +1,8 @@
-{% comment %} {# Document icon (single item). Usage: {% include "components/icons/document.html" with classes="w-4 h-4" %} #} {% endcomment %}
-<svg xmlns="http://www.w3.org/2000/svg" class="{{ classes|default:'w-4 h-4' }}" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-  <path d="M16.5 3.75H7.5a1.5 1.5 0 00-1.5 1.5v13.5A1.5 1.5 0 007.5 20.25h9a1.5 1.5 0 001.5-1.5V5.25a1.5 1.5 0 00-1.5-1.5zM9 7.5h6M9 12h6M9 16.5h3"/>
+{% comment %} {# Document icon (single item, outline). Usage: {% include "components/icons/document.html" with classes="w-4 h-4" %} #} {% endcomment %}
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ classes|default:'w-4 h-4' }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+  <rect x="6" y="3" width="12" height="18" rx="2" ry="2"></rect>
+  <line x1="9" y1="8" x2="15" y2="8"></line>
+  <line x1="9" y1="12" x2="15" y2="12"></line>
+  <line x1="9" y1="16" x2="12" y2="16"></line>
+  <title>Document</title>
 </svg>

--- a/census_app/templates/components/icons/documents.html
+++ b/census_app/templates/components/icons/documents.html
@@ -1,5 +1,6 @@
-{% comment %} {# Documents icon (question groups). Usage: {% include "components/icons/documents.html" with classes="w-4 h-4" %} #} {% endcomment %}
-<svg xmlns="http://www.w3.org/2000/svg" class="{{ classes|default:'w-4 h-4' }}" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-  <path d="M7 3h8a2 2 0 012 2v9a2 2 0 01-2 2H7a2 2 0 01-2-2V5a2 2 0 012-2z"/>
-  <path d="M9 7h8a2 2 0 012 2v9a2 2 0 01-2 2H9a2 2 0 01-2-2V9a2 2 0 012-2z"/>
+{% comment %} {# Documents icon (two overlapping, outline). Usage: {% include "components/icons/documents.html" with classes="w-4 h-4" %} #} {% endcomment %}
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ classes|default:'w-4 h-4' }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+  <rect x="5" y="4" width="11" height="15" rx="2" ry="2"></rect>
+  <rect x="8" y="7" width="11" height="15" rx="2" ry="2"></rect>
+  <title>Documents</title>
 </svg>

--- a/census_app/templates/components/icons/users.html
+++ b/census_app/templates/components/icons/users.html
@@ -1,0 +1,12 @@
+{% comment %} {# People/users icon (outline). Usage: {% include "components/icons/users.html" with classes="w-5 h-5 text-primary" %} #} {% endcomment %}
+<svg xmlns="http://www.w3.org/2000/svg" class="{{ classes|default:'w-5 h-5' }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+  <!-- Head 1 -->
+  <circle cx="8" cy="8" r="3" />
+  <!-- Head 2 -->
+  <circle cx="16" cy="9" r="3" />
+  <!-- Body 1 -->
+  <path d="M3.5 19a4.5 4.5 0 0 1 9 0v1.5H3.5V19Z" />
+  <!-- Body 2 (slightly offset) -->
+  <path d="M12 19a4 4 0 0 1 8 0v1.5H12V19Z" />
+  <title>Users</title>
+</svg>


### PR DESCRIPTION
This PR applies UI polish and small UX fixes:

- Primary-colored secondary headings across Surveys, Groups, User Management, and Profile
- Switch document/documents icons to outline; add users and building outline icons (currentColor-driven)
- Replace Profile Appearance select with a DaisyUI dropdown; fix item selection and state sync; close on selection
- Groups/Builder: ensure group name links to builder; clear form after add; reorder auto-saves; toast scaffolding
- Swagger/ReDoc links remain; no behavior changes to API

Validation
- Tests: 69 passed locally in Docker
- Lint: Ruff OK; Black/isort intentionally deferred to a follow-up PR to keep this diff focused
