### PR TITLE
UI fixes (OIDC branch): link groups to builder, prevent form refresh after add

### DIFF
--- a/census_app/static/js/builder.js
+++ b/census_app/static/js/builder.js
@@ -71,83 +71,98 @@
     renumberQuestions(document);
   });
 
-  if (window.htmx) {
-    // Add CSRF header to all HTMX requests
-    document.body.addEventListener("htmx:configRequest", function (evt) {
-      evt.detail.headers["X-CSRFToken"] = csrfToken();
-    });
-    // Re-init Sortable after swaps that touch the questions list
-    document.body.addEventListener("htmx:afterSwap", function (evt) {
-      const target = (evt.detail && evt.detail.target) || evt.target;
-      if (!target) return;
-      if (
-        target.id === "questions-list" ||
-        (target.closest && target.closest("#questions-list"))
-      ) {
-        initSortable(document);
-        scheduleDismissals(document);
-        renumberQuestions(document);
-        // If this swap was triggered by the create-question form submission, reset the form
-        const src = evt.detail && evt.detail.elt ? evt.detail.elt : null;
-        const form = document.getElementById("create-question-form");
-        if (
-          src &&
-          form &&
-          (src === form ||
-            (src.closest && src.closest("#create-question-form")))
-        ) {
-          // Reset to initial defaults
-          form.reset();
-          // Re-apply conditional visibility based on defaults
-          if (typeof form._refreshCreateToggles === "function") {
-            form._refreshCreateToggles();
-          } else {
-            // Fallback: trigger a change event to force recompute
-            const evtChange = new Event("change", { bubbles: true });
-            const checkedType = form.querySelector(
-              'input[name="type"]:checked'
-            );
-            if (checkedType) checkedType.dispatchEvent(evtChange);
-          }
-          // Focus first usable input for faster entry
-          const firstField = form.querySelector(
-            "input:not([type=hidden]):not([disabled]), textarea, select"
-          );
-          if (firstField && firstField.focus) firstField.focus();
-        }
-      }
-      // Re-bind toggles for the create form if present
-      if (document.getElementById("create-question-form")) {
-        initCreateFormToggles();
-      }
-    });
+  // Add CSRF header to all HTMX requests
+  document.body.addEventListener("htmx:configRequest", function (evt) {
+    evt.detail.headers["X-CSRFToken"] = csrfToken();
+  });
 
-    // Also reset form after the request completes successfully, even if no swap occurred
-    document.body.addEventListener("htmx:afterRequest", function (evt) {
+  // Disable the Add button while submitting to avoid double posts
+  document.body.addEventListener("htmx:beforeRequest", function (evt) {
+    const src = evt.detail && evt.detail.elt ? evt.detail.elt : null;
+    const form = document.getElementById("create-question-form");
+    if (
+      src &&
+      form &&
+      (src === form || (src.closest && src.closest("#create-question-form")))
+    ) {
+      const btn = form.querySelector('button[type="submit"]');
+      if (btn) btn.disabled = true;
+    }
+  });
+  // Re-init Sortable after swaps that touch the questions list
+  document.body.addEventListener("htmx:afterSwap", function (evt) {
+    const target = (evt.detail && evt.detail.target) || evt.target;
+    if (!target) return;
+    if (
+      target.id === "questions-list" ||
+      (target.closest && target.closest("#questions-list"))
+    ) {
+      initSortable(document);
+      scheduleDismissals(document);
+      renumberQuestions(document);
+      // If this swap was triggered by the create-question form submission, reset the form
       const src = evt.detail && evt.detail.elt ? evt.detail.elt : null;
+      const form = document.getElementById("create-question-form");
       if (
-        !src ||
-        !(
-          src.id === "create-question-form" ||
-          (src.closest && src.closest("#create-question-form"))
-        )
-      )
-        return;
-      const xhr = evt.detail && evt.detail.xhr ? evt.detail.xhr : null;
-      if (xhr && xhr.status >= 200 && xhr.status < 300) {
-        const form = document.getElementById("create-question-form") || src;
-        if (!form) return;
+        src &&
+        form &&
+        (src === form || (src.closest && src.closest("#create-question-form")))
+      ) {
+        // Reset to initial defaults
         form.reset();
+        // Re-apply conditional visibility based on defaults
         if (typeof form._refreshCreateToggles === "function") {
           form._refreshCreateToggles();
+        } else {
+          // Fallback: trigger a change event to force recompute
+          const evtChange = new Event("change", { bubbles: true });
+          const checkedType = form.querySelector('input[name="type"]:checked');
+          if (checkedType) checkedType.dispatchEvent(evtChange);
         }
+        // Focus first usable input for faster entry
         const firstField = form.querySelector(
           "input:not([type=hidden]):not([disabled]), textarea, select"
         );
         if (firstField && firstField.focus) firstField.focus();
       }
-    });
-  }
+    }
+    // Re-bind toggles for the create form if present
+    if (document.getElementById("create-question-form")) {
+      initCreateFormToggles();
+    }
+  });
+
+  // Also reset form after the request completes successfully, even if no swap occurred
+  document.body.addEventListener("htmx:afterRequest", function (evt) {
+    const src = evt.detail && evt.detail.elt ? evt.detail.elt : null;
+    if (
+      !src ||
+      !(
+        src.id === "create-question-form" ||
+        (src.closest && src.closest("#create-question-form"))
+      )
+    )
+      return;
+    const xhr = evt.detail && evt.detail.xhr ? evt.detail.xhr : null;
+    if (xhr && xhr.status >= 200 && xhr.status < 300) {
+      const form = document.getElementById("create-question-form") || src;
+      if (!form) return;
+      form.reset();
+      if (typeof form._refreshCreateToggles === "function") {
+        form._refreshCreateToggles();
+      }
+      const firstField = form.querySelector(
+        "input:not([type=hidden]):not([disabled]), textarea, select"
+      );
+      if (firstField && firstField.focus) firstField.focus();
+    }
+    // Always re-enable submit button after request completes
+    const form = document.getElementById("create-question-form") || src;
+    if (form) {
+      const btn = form.querySelector('button[type="submit"]');
+      if (btn) btn.disabled = false;
+    }
+  });
 
   function initCreateFormToggles() {
     const form = document.getElementById("create-question-form");

--- a/census_app/static/js/groups-page.js
+++ b/census_app/static/js/groups-page.js
@@ -57,10 +57,9 @@
         e.target.closest(".select-checkbox")
       )
         return;
+      // If the click is on a builder link, allow normal navigation
       var a = e.target.closest('a[href*="/builder/"]');
-      if (a && !(e.metaKey || e.ctrlKey || e.shiftKey)) {
-        e.preventDefault();
-      }
+      if (a) return;
       var cb = li.querySelector(".select-checkbox");
       if (!cb) return;
       cb.checked = !cb.checked;

--- a/census_app/surveys/templates/surveys/group_builder.html
+++ b/census_app/surveys/templates/surveys/group_builder.html
@@ -142,5 +142,6 @@ Strongly agree"></textarea>
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
-<script src="{% static 'js/builder.js' %}"></script>
+<script src="{% static 'js/builder.js' %}?v={{ build.commit|default:build.timestamp }}">
+</script>
 {% endblock %}

--- a/census_app/surveys/templates/surveys/groups.html
+++ b/census_app/surveys/templates/surveys/groups.html
@@ -196,6 +196,6 @@
 
 {% block extra_js %}
 <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
-  <script src="{% static 'js/groups.js' %}"></script>
-  <script src="{% static 'js/groups-page.js' %}"></script>
+  <script src="{% static 'js/groups.js' %}?v={{ build.commit|default:build.timestamp }}"></script>
+  <script src="{% static 'js/groups-page.js' %}?v={{ build.commit|default:build.timestamp }}"></script>
 {% endblock %}


### PR DESCRIPTION
This PR cherry-picks remaining UI items originally sitting on the OIDC branch:

- Make group name navigate to Questions/Builder
- After adding a question, clear the form and prevent full-page refresh

These align with the recently merged UI polish PR and fill the gap for the earlier branch.

Validation
- Tests: pass locally in Docker (same suite as ui-fixes PR)
- Lint: Ruff OK previously; formatting (Black/isort) deferred to a later housekeeping PR