### PR TITLE
Update docker-publish workflow to build on main branch

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,6 +2,7 @@ name: Build and Publish Docker Images
 
 on:
     push:
+        branches: [main]
         tags: ["v*"]
     release:
         types: [published]


### PR DESCRIPTION
## Summary

Update the docker-publish workflow to build and publish Docker images on every push to main branch.

## Changes

- Add `main` branch to push triggers
- Ensures Docker images are immediately available on ghcr.io after PR merges
- Keeps existing triggers: tags, releases, manual dispatch

## Why

Currently, the workflow only runs on tags/releases, which means self-hosters can't pull the image until a release is created. Building on main branch pushes makes the latest code immediately available as `ghcr.io/eatyourpeas/census:latest`.

## Testing

Once merged, the workflow will automatically:
1. Build multi-arch images (amd64/arm64)
2. Push to ghcr.io
3. Tag as `:latest` and `:main-<sha>`