### PR TITLE
Docker-publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -76,7 +76,7 @@ jobs:
           echo "3. Visit: http://localhost:8000" >> deployment-artifacts/README.md
 
       - name: Upload deployment artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v5
         with:
           name: census-deployment-${{ github.ref_name }}
           path: deployment-artifacts/


### PR DESCRIPTION
this failed following merge because v3 of actions/upload-artifact is now deprecated.
version bump now to 5.0 (published 2 days ago)