### PR TITLE
Fix DaisyUI tabs and radio button styles in production

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,7 +8,7 @@ module.exports = {
   content: [
     "./checktick_app/templates/**/*.html",
     "./checktick_app/**/templates/**/*.html",
-  ],
+  ], // Cache bust: 2025-11-02
   theme: {
     extend: {
       typography: ({ theme }) => ({


### PR DESCRIPTION
## Problem
DaisyUI tabs and radio buttons were not rendering correctly in production, despite working fine in development.

## Root Cause
Production was serving an old cached CSS file that was built before DaisyUI component classes were added. The CSS file contained theme variables but was missing the actual component styles (, , etc.).

## Solution
Added a cache-busting comment to  to force Northflank to rebuild the CSS from scratch, ensuring all DaisyUI component classes are included in the production build.

## Testing
- [ ] Verify tabs render correctly in production
- [ ] Verify radio buttons render correctly in production
- [ ] Confirm group_builder.html displays properly