### PR TITLE
Force CSS manifest rebuild to fix DaisyUI components in production

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,7 +8,7 @@ module.exports = {
   content: [
     "./checktick_app/templates/**/*.html",
     "./checktick_app/**/templates/**/*.html",
-  ], // Cache bust: 2025-11-02
+  ], // Cache bust: 2025-11-02 14:30 - Force manifest rebuild
   theme: {
     extend: {
       typography: ({ theme }) => ({


### PR DESCRIPTION
## Problem

Production is currently serving an old CSS file (`styles.99ed692abf4f.css`) that was built before DaisyUI components were added. This means:
- Tabs with `tabs-lift` class are not rendering correctly
- Radio buttons with `radio-primary` class are not displaying properly
- Button text shows black instead of white (incorrect theme colors)

Even though the code was redeployed multiple times, the Docker build cache caused the static files manifest to continue referencing the old CSS hash.

## Root Cause

Django's `CompressedManifestStaticFilesStorage` creates a manifest file during `collectstatic` that maps original filenames to hashed versions. The hash is based on file content. Because the Docker build was using cached layers, the manifest wasn't regenerated with a new hash for the updated CSS file.

## Solution

This PR updates the cache-bust comment in `tailwind.config.js` from:
```javascript
], // Cache bust: 2025-11-02
```

to:
```javascript
], // Cache bust: 2025-11-02 14:30 - Force manifest rebuild
```

This ensures:
1. Tailwind config file content changes
2. Docker rebuild process generates new CSS
3. `collectstatic` creates a new manifest with a fresh hash
4. Production serves the new CSS file with all DaisyUI components

## Verification

After deployment, verify:
1. The CSS filename in production HTML source has a **different hash** than `99ed692abf4f`
2. Tabs with `class="tabs tabs-lift"` render with proper styling
3. Radio buttons with `class="radio radio-primary"` display correctly
4. Primary buttons show **white text** (not black)

## Related

- Original issue: #70
- The DaisyUI components were added in the previous PR but weren't appearing in production due to the manifest cache issue