### PR TITLE
Add Northflank deployment webhook for automated CI/CD

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Trigger Northflank deployment
         if: github.ref == 'refs/heads/main'
         env:
-          NF_API_TOKEN: ${{ secrets.NORTHFLANK_API_TOKEN }}
+          NF_API_TOKEN: ${{ secrets.NORTHFLANKAPIKEY }}
           NF_PROJECT_ID: ${{ secrets.NORTHFLANK_PROJECT_ID }}
           NF_SERVICE_ID: ${{ secrets.NORTHFLANK_SERVICE_ID }}
         run: |


### PR DESCRIPTION
## Summary

This PR adds automated deployment triggering to Northflank after successful Docker image builds, enabling full CI/CD pipeline: **Push to main → Build → Publish → Deploy**.

## Changes

Adds a new workflow step that triggers Northflank deployment webhook after:
- ✅ Docker image is built successfully
- ✅ Image is pushed to GHCR.io
- ✅ Only runs on `main` branch (production deployments)

## Features

- **Graceful degradation**: Safely skips if `NORTHFLANK_DEPLOY_WEBHOOK` secret isn't configured
- **Clear logging**: Shows deployment trigger status in workflow logs
- **Fork-friendly**: Won't break workflow for contributors who don't have the secret
- **Non-blocking**: Logs warning if webhook fails but doesn't fail the workflow

## Setup Required After Merge

1. **Get webhook URL from Northflank**:
   - Go to your service in Northflank
   - Navigate to Settings/CI-CD section
   - Copy the "Deploy Webhook" URL

2. **Add as GitHub secret**:
   - Go to: https://github.com/eatyourpeas/checktick/settings/secrets/actions
   - Click "New repository secret"
   - Name: `NORTHFLANK_DEPLOY_WEBHOOK`
   - Value: The webhook URL from step 1

3. **Test**: Push a small change to main and verify deployment triggers automatically

## Benefits

- ⚡ Faster deployments (no manual trigger needed)
- �� Consistent deployment process
- 🎯 Deploy exactly what was built and tested in CI
- 📦 Solves the manifest cache issue (fresh build every time)