### PR TITLE
Force manifest regeneration on each deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ ENV PORT=8000
 
 EXPOSE 8000
 
-CMD ["sh", "-lc", "python manage.py migrate --noinput && python manage.py collectstatic --noinput && gunicorn checktick_app.wsgi:application --bind 0.0.0.0:${PORT} --workers 3"]
+CMD ["sh", "-lc", "python manage.py migrate --noinput && rm -f staticfiles/staticfiles.json && python manage.py collectstatic --noinput && gunicorn checktick_app.wsgi:application --bind 0.0.0.0:${PORT} --workers 3"]


### PR DESCRIPTION
## Problem

Production CSS hash remained stuck at `styles.99ed692abf4f.css` even after fresh deployments from GHCR, causing DaisyUI tabs and radio buttons to render incorrectly.

## Root Cause

Django's `staticfiles.json` manifest file was persisting between deployments (likely in a volume or persistent storage), causing `collectstatic` to reuse the old manifest instead of regenerating it with fresh CSS hashes.

## Solution

Delete `staticfiles/staticfiles.json` before running `collectstatic` in the container startup command. This forces Django to:
1. Hash all static files fresh (including the newly built CSS)
2. Generate a new manifest with correct hashes
3. Serve the updated CSS file

## Expected Result

After this deployment, the CSS hash should change from `99ed692abf4f` to a new value, and DaisyUI components (tabs, radio buttons) should render correctly with proper styling.

## Testing

1. Deploy this PR
2. Clear browser cache and hard refresh
3. Check CSS filename in page source - should be different hash
4. Verify tabs and radio buttons display correctly