### PR TITLE
Use --clear flag for collectstatic to force fresh manifest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ ENV PORT=8000
 
 EXPOSE 8000
 
-CMD ["sh", "-lc", "python manage.py migrate --noinput && rm -f staticfiles/staticfiles.json && python manage.py collectstatic --noinput && gunicorn checktick_app.wsgi:application --bind 0.0.0.0:${PORT} --workers 3"]
+CMD ["sh", "-lc", "python manage.py migrate --noinput && python manage.py collectstatic --noinput --clear && gunicorn checktick_app.wsgi:application --bind 0.0.0.0:${PORT} --workers 3"]


### PR DESCRIPTION
## Problem

Even after deleting `staticfiles.json` manually, the CSS hash remained `99ed692abf4f`. This suggests Northflank may be using a persistent volume for the staticfiles directory.

## Root Cause

The `rm -f staticfiles/staticfiles.json` approach doesn't work reliably when:
- The staticfiles directory doesn't exist yet at that point in startup
- Northflank is mounting a persistent volume for staticfiles
- The manifest is being restored from a volume mount

## Solution

Use Django's built-in `--clear` flag for collectstatic:
```bash
python manage.py collectstatic --noinput --clear
```

This flag:
- Deletes ALL files in the staticfiles directory before collecting
- Forces complete regeneration of everything including the manifest
- Handles persistent volume scenarios correctly
- Is the official Django way to force a fresh collect

## Expected Result

After this deployment:
- staticfiles directory is completely cleared
- All static files are freshly collected from source
- New manifest is generated with correct CSS hash
- CSS hash should finally change from `99ed692abf4f`
- DaisyUI components render correctly