### PR TITLE
Use find command to delete manifest instead of --clear

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ ENV PORT=8000
 
 EXPOSE 8000
 
-CMD ["sh", "-lc", "python manage.py migrate --noinput && python manage.py collectstatic --noinput --clear && gunicorn checktick_app.wsgi:application --bind 0.0.0.0:${PORT} --workers 3"]
+CMD ["sh", "-lc", "python manage.py migrate --noinput && find /app/staticfiles -name 'staticfiles.json' -delete && python manage.py collectstatic --noinput && gunicorn checktick_app.wsgi:application --bind 0.0.0.0:${PORT} --workers 3"]


### PR DESCRIPTION
## Problem

The `--clear` flag causes Out of Memory errors on free tier Northflank instances:
```
[ERROR] Worker (pid:21) was sent SIGKILL! Perhaps out of memory?
[CRITICAL] WORKER TIMEOUT
```

The `--clear` flag deletes ALL static files (including Django admin, REST framework, etc.) before collecting, which is too memory-intensive.

## Solution

Use a targeted `find` command to delete only the manifest file:
```bash
find /app/staticfiles -name 'staticfiles.json' -delete
```

This:
- Only deletes the one problematic manifest file
- Handles persistent volume scenarios (finds it anywhere)
- Much more memory-efficient
- Works on free tier instances
- Still forces manifest regeneration

## Expected Result

- No OOM errors during deployment
- Manifest is deleted and regenerated
- CSS hash finally changes from `99ed692abf4f`
- DaisyUI components render correctly

## Note

After merging, also delete the old Northflank build service (the one that builds from GitHub but doesn't deploy) to free up resources.