### PR TITLE
Use collectstatic --clear flag with 1GB RAM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ ENV PORT=8000
 
 EXPOSE 8000
 
-CMD ["sh", "-lc", "python manage.py migrate --noinput && find /app/staticfiles -name 'staticfiles.json' -delete && python manage.py collectstatic --noinput && gunicorn checktick_app.wsgi:application --bind 0.0.0.0:${PORT} --workers 3"]
+CMD ["sh", "-lc", "python manage.py migrate --noinput && python manage.py collectstatic --noinput --clear && gunicorn checktick_app.wsgi:application --bind 0.0.0.0:${PORT} --workers 3"]


### PR DESCRIPTION
## Problem
The `find` command workaround from PR #75 didn't work because:
- `staticfiles.json` doesn't exist until DURING collectstatic
- Django's manifest cache persists server-side, not just in the container

## Solution
Use Django's proper `--clear` flag which:
- Clears the entire staticfiles directory before collecting
- Forces complete manifest regeneration
- Is the recommended Django approach

## Why Now?
Previously failed with OOM on `nf-compute-10` (256MB RAM).
Now safe to use with `nf-compute-50` (1GB RAM).

## Expected Result
Production CSS hash will finally change from `styles.99ed692abf4f.css` to a fresh hash with DaisyUI components included.

Fixes the persistent CSS issue that survived PRs #70, #71, #73, #74, and #75.