### PR TITLE
Fix: Add --clear flag to Dockerfile.registry

### DIFF
--- a/Dockerfile.registry
+++ b/Dockerfile.registry
@@ -54,4 +54,4 @@ HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/api/health || exit 1
 
 # Default command
-CMD ["sh", "-c", "python manage.py migrate --noinput && python manage.py collectstatic --noinput && gunicorn checktick_app.wsgi:application --bind 0.0.0.0:8000 --workers 4"]
+CMD ["sh", "-c", "python manage.py migrate --noinput && python manage.py collectstatic --noinput --clear && gunicorn checktick_app.wsgi:application --bind 0.0.0.0:8000 --workers 4"]


### PR DESCRIPTION
PR #76 added --clear flag to Dockerfile but missed Dockerfile.registry. GitHub Actions uses Dockerfile.registry so the deployed image never got the fix. This is why the CSS hash still didn't change despite successful deployments.