### PR TITLE
Remove CompressedManifestStaticFilesStorage to fix stale CSS

### DIFF
--- a/Dockerfile.registry
+++ b/Dockerfile.registry
@@ -52,5 +52,5 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/api/health || exit 1
 
-# Default command - build CSS at runtime to avoid Docker cache issues
-CMD ["sh", "-c", "npm run build:css && python manage.py migrate --noinput && python manage.py collectstatic --noinput --clear && gunicorn checktick_app.wsgi:application --bind 0.0.0.0:8000 --workers 4"]
+# Default command - build CSS at runtime to ensure fresh styles
+CMD ["sh", "-c", "npm run build:css && python manage.py migrate --noinput && python manage.py collectstatic --noinput && gunicorn checktick_app.wsgi:application --bind 0.0.0.0:8000 --workers 4"]

--- a/checktick_app/settings.py
+++ b/checktick_app/settings.py
@@ -166,30 +166,21 @@ STATIC_URL = "/static/"
 STATIC_ROOT = BASE_DIR / "staticfiles"
 STATICFILES_DIRS = [BASE_DIR / "checktick_app" / "static"]
 
-# WhiteNoise configuration with cache busting
+# WhiteNoise configuration
 WHITENOISE_USE_FINDERS = True
 WHITENOISE_MAX_AGE = 31536000 if not DEBUG else 0
 
-# Use manifest storage with cache busting in production only
-# In development/testing, use regular storage to avoid collectstatic requirement
-if DEBUG:
-    STORAGES = {
-        "default": {
-            "BACKEND": "django.core.files.storage.FileSystemStorage",
-        },
-        "staticfiles": {
-            "BACKEND": "whitenoise.storage.CompressedStaticFilesStorage",
-        },
-    }
-else:
-    STORAGES = {
-        "default": {
-            "BACKEND": "django.core.files.storage.FileSystemStorage",
-        },
-        "staticfiles": {
-            "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
-        },
-    }
+# Use same storage backend in dev and production to avoid manifest caching issues
+# CompressedStaticFilesStorage provides compression and proper cache headers
+# without the manifest hash that was causing stale CSS issues
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedStaticFilesStorage",
+    },
+}
 
 # Media uploads (used for admin-uploaded icons if configured)
 MEDIA_URL = "/media/"


### PR DESCRIPTION
The manifest storage was caching old CSS hashes. Using CompressedStaticFilesStorage in production (same as dev) provides compression and proper caching without the persistent manifest hash issue.