### PR TITLE
Fix CSS cache-busting for DaisyUI components

### DIFF
--- a/checktick_app/templates/base.html
+++ b/checktick_app/templates/base.html
@@ -11,7 +11,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   {% if brand.font_css_url %}<link href="{{ brand.font_css_url }}" rel="stylesheet">{% endif %}
   {% block head_fonts %}{% endblock %}
-    <link rel="stylesheet" href="{% static 'build/styles.css' %}">
+    <link rel="stylesheet" href="{% static 'build/styles.css' %}?v={{ build.timestamp }}">
     {% if brand.theme_css_light or brand.theme_css_dark %}
     <style>
       {% if brand.theme_css_light %}


### PR DESCRIPTION
## Problem
DaisyUI tabs and radio buttons were not rendering in production despite the CSS file containing the correct styles.

## Root Cause
The CSS link in base.html had no cache-busting parameter, causing browsers to load stale cached CSS files even after deployments with updated styles.

## Solution
Added `?v={{ build.timestamp }}` query parameter to the CSS link, ensuring browsers fetch fresh CSS on every deployment.

## Testing
- [x] Verified production CSS contains DaisyUI styles
- [x] Ran collectstatic successfully in production container
- [ ] After merge: Hard refresh browser and confirm tabs/radio buttons render

Fixes: DaisyUI component rendering in production