### PR TITLE
Add fallback date to CSS cache-busting

### DIFF
--- a/checktick_app/templates/base.html
+++ b/checktick_app/templates/base.html
@@ -11,7 +11,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   {% if brand.font_css_url %}<link href="{{ brand.font_css_url }}" rel="stylesheet">{% endif %}
   {% block head_fonts %}{% endblock %}
-    <link rel="stylesheet" href="{% static 'build/styles.css' %}?v={{ build.timestamp }}">
+    <link rel="stylesheet" href="{% static 'build/styles.css' %}?v={{ build.commit|default:build.timestamp|default:'20251102' }}">
     {% if brand.theme_css_light or brand.theme_css_dark %}
     <style>
       {% if brand.theme_css_light %}


### PR DESCRIPTION
Adds a static date fallback (20251102) to the CSS cache-busting parameter to handle cases where build.commit and build.timestamp are None due to missing environment variables in Northflank.