### PR TITLE
Fix CSS caching with hash-based filename

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,11 @@ COPY CONTRIBUTING.md ./
 RUN poetry install --only main --no-interaction --no-ansi
 RUN npm run build:css
 
+# Create a versioned copy of the CSS file with hash in filename
+RUN CSS_HASH=$(md5sum checktick_app/static/build/styles.css | cut -d' ' -f1 | cut -c1-8) && \
+    cp checktick_app/static/build/styles.css checktick_app/static/build/styles.$CSS_HASH.css && \
+    echo $CSS_HASH > /tmp/css_hash.txt
+
 RUN adduser --disabled-login --gecos "" appuser
 RUN mkdir -p /app/staticfiles /app/media && \
     chown -R appuser:appuser /app/staticfiles /app/media

--- a/checktick_app/context_processors.py
+++ b/checktick_app/context_processors.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+from pathlib import Path
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
@@ -198,6 +199,17 @@ def branding(request):
             version_val = _importlib_metadata.version("checktick")
         except Exception:
             version_val = None
+
+    # Get CSS hash from file or environment for cache-busting
+    css_hash = os.environ.get("CSS_HASH")
+    if not css_hash:
+        try:
+            hash_file = Path("/tmp/css_hash.txt")
+            if hash_file.exists():
+                css_hash = hash_file.read_text().strip()
+        except Exception:
+            pass
+
     build = {
         "version": version_val or "dev",
         "timestamp": os.environ.get("BUILD_TIMESTAMP")
@@ -205,6 +217,7 @@ def branding(request):
         "commit": git.get("commit"),
         "branch": git.get("branch"),
         "commit_date": git.get("commit_date"),
+        "css_hash": css_hash or "dev",
     }
 
     return {

--- a/checktick_app/templates/base.html
+++ b/checktick_app/templates/base.html
@@ -11,7 +11,11 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   {% if brand.font_css_url %}<link href="{{ brand.font_css_url }}" rel="stylesheet">{% endif %}
   {% block head_fonts %}{% endblock %}
-    <link rel="stylesheet" href="{% static 'build/styles.css' %}?v={{ build.commit|default:build.timestamp|default:'20251102' }}">
+    {% if build.css_hash and build.css_hash != 'dev' %}
+    <link rel="stylesheet" href="{% static 'build/styles.' %}{{ build.css_hash }}.css">
+    {% else %}
+    <link rel="stylesheet" href="{% static 'build/styles.css' %}">
+    {% endif %}
     {% if brand.theme_css_light or brand.theme_css_dark %}
     <style>
       {% if brand.theme_css_light %}


### PR DESCRIPTION
## Problem
Browser caching was preventing updated CSS from loading, even with query parameter cache-busting. The browser was serving a cached 31KB old CSS file instead of the new 145KB file with DaisyUI components.

## Solution
Changed from query parameter cache-busting (?v=...) to hash-based filename (styles.8656c6bb.css):
- Dockerfile now creates versioned CSS file with MD5 hash in filename
- Context processor reads hash from file/environment
- Template uses hashed filename when available, falls back to regular filename in dev

## Why this works
Changing the filename itself forces browsers to fetch the new file as it's a completely different resource, bypassing all HTTP caching layers.

## Testing
- [x] Local build creates hashed file
- [ ] Production deployment creates correct hashed filename
- [ ] DaisyUI tabs and radio buttons render correctly