### PR TITLE
Update DaisyUI theme selectors

### DIFF
--- a/checktick_app/static/css/daisyui_themes.css
+++ b/checktick_app/static/css/daisyui_themes.css
@@ -16,8 +16,8 @@
 }
 
 @layer base {
-  :root:where([data-theme="checktick"]),
-  :where([data-theme="checktick-light"]) {
+  [data-theme="checktick"],
+  [data-theme="checktick-light"] {
     color-scheme: light;
 
     /* Colors */
@@ -77,42 +77,41 @@
     --color-error-content: var(--erc);
   }
 
-:root:where([data-theme="checktick-dark"]) {
-  color-scheme: dark;
+  [data-theme="checktick-dark"] {
+    color-scheme: dark;
 
-  /* Colors from your DaisyUI builder output */
-  --color-base-100: oklch(70% 0.04 256.788);
-  --color-base-200: oklch(37% 0.034 259.733);
-  --color-base-300: oklch(37% 0.013 285.805);
-  --color-base-content: oklch(96% 0.007 247.896);
-  --color-primary: #6d5aa5;
-  --color-primary-content: oklch(98% 0.002 247.839);
-  --color-secondary: oklch(59% 0.145 163.225);
-  --color-secondary-content: oklch(98% 0.003 247.858);
-  --color-accent: oklch(71% 0.143 215.221);
-  --color-accent-content: oklch(98% 0.003 247.858);
-  --color-neutral: oklch(52% 0.105 223.128);
-  --color-neutral-content: oklch(98% 0 0);
-  --color-info: oklch(60% 0.126 221.723);
-  --color-info-content: oklch(98% 0.019 200.873);
-  --color-success: oklch(60% 0.118 184.704);
-  --color-success-content: oklch(98% 0.031 120.757);
-  --color-warning: oklch(66% 0.179 58.318);
-  --color-warning-content: oklch(98% 0.022 95.277);
-  --color-error: oklch(58% 0.253 17.585);
-  --color-error-content: oklch(96% 0.015 12.422);
+    /* Colors from your DaisyUI builder output */
+    --color-base-100: oklch(70% 0.04 256.788);
+    --color-base-200: oklch(37% 0.034 259.733);
+    --color-base-300: oklch(37% 0.013 285.805);
+    --color-base-content: oklch(96% 0.007 247.896);
+    --color-primary: #6d5aa5;
+    --color-primary-content: oklch(98% 0.002 247.839);
+    --color-secondary: oklch(59% 0.145 163.225);
+    --color-secondary-content: oklch(98% 0.003 247.858);
+    --color-accent: oklch(71% 0.143 215.221);
+    --color-accent-content: oklch(98% 0.003 247.858);
+    --color-neutral: oklch(52% 0.105 223.128);
+    --color-neutral-content: oklch(98% 0 0);
+    --color-info: oklch(60% 0.126 221.723);
+    --color-info-content: oklch(98% 0.019 200.873);
+    --color-success: oklch(60% 0.118 184.704);
+    --color-success-content: oklch(98% 0.031 120.757);
+    --color-warning: oklch(66% 0.179 58.318);
+    --color-warning-content: oklch(98% 0.022 95.277);
+    --color-error: oklch(58% 0.253 17.585);
+    --color-error-content: oklch(96% 0.015 12.422);
 
-  /* Spacing & Radii */
-  --radius-selector: 0.25rem;
-  --radius-field: 0.25rem;
-  --radius-box: 0.25rem;
-  --size-selector: 0.25rem;
-  --size-field: 0.28125rem;
-  --border: 1px;
-  --depth: 0;
-  --noise: 0;
-}
-
+    /* Spacing & Radii */
+    --radius-selector: 0.25rem;
+    --radius-field: 0.25rem;
+    --radius-box: 0.25rem;
+    --size-selector: 0.25rem;
+    --size-field: 0.28125rem;
+    --border: 1px;
+    --depth: 0;
+    --noise: 0;
+  }
 }
 
 @layer components {

--- a/docker-compose.registry.yml
+++ b/docker-compose.registry.yml
@@ -15,7 +15,7 @@ services:
   web:
     image: ghcr.io/eatyourpeas/checktick:latest
     ports:
-      - "8000:8000"
+      - "${HOST_PORT:-8000}:8000"
     volumes:
       # Persist uploaded files and user-generated content
       - media_data:/app/media


### PR DESCRIPTION
## Summary
- fix DaisyUI theme selectors to match data-theme attributes without :root scoping
- ensure docker registry compose file forwards configurable host port for prod-test stacks

## Testing
- docker compose -p checktick-prod-test -f docker-compose.registry.yml up -d --force-recreate web