### PR TITLE
Add sRGB fallbacks for DaisyUI themes

### DIFF
--- a/checktick_app/static/css/daisyui_themes.css
+++ b/checktick_app/static/css/daisyui_themes.css
@@ -20,27 +20,27 @@
   [data-theme="checktick-light"] {
     color-scheme: light;
 
-    /* Colors */
+    /* Colors (sRGB fallbacks) */
     --p: #6d5aa5;
-    --pc: oklch(98% 0.002 247.839);
-    --s: oklch(59% 0.145 163.225);
-    --sc: oklch(98% 0.003 247.858);
-    --a: oklch(71% 0.143 215.221);
-    --ac: oklch(98% 0.003 247.858);
-    --n: oklch(45% 0.085 224.283);
-    --nc: oklch(98% 0 0);
-    --b1: oklch(98% 0 0);
-    --b2: oklch(96% 0.001 286.375);
-    --b3: oklch(92% 0.004 286.32);
-    --bc: oklch(21% 0.006 285.885);
-    --in: oklch(60% 0.126 221.723);
-    --inc: oklch(98% 0.126 221.723);
-    --su: oklch(60% 0.118 184.704);
-    --suc: oklch(98% 0.031 120.757);
-    --wa: oklch(66% 0.179 58.318);
-    --wac: oklch(98% 0.022 95.277);
-    --er: oklch(58% 0.253 17.585);
-    --erc: oklch(96% 0.015 12.422);
+    --pc: #ffffff;
+    --s: #5c7ad6;
+    --sc: #ffffff;
+    --a: #49a5e5;
+    --ac: #ffffff;
+    --n: #3f4263;
+    --nc: #ffffff;
+    --b1: #ffffff;
+    --b2: #f5f6ff;
+    --b3: #e7ebff;
+    --bc: #2a2a3d;
+    --in: #3a9ddc;
+    --inc: #ffffff;
+    --su: #2f8f58;
+    --suc: #f0fff4;
+    --wa: #d79a32;
+    --wac: #fff6da;
+    --er: #c0443b;
+    --erc: #fff2f0;
 
     /* Spacing & Radii */
     --rounded-selector: 0.25rem;
@@ -80,27 +80,27 @@
   [data-theme="checktick-dark"] {
     color-scheme: dark;
 
-    /* Colors from your DaisyUI builder output */
-    --color-base-100: oklch(70% 0.04 256.788);
-    --color-base-200: oklch(37% 0.034 259.733);
-    --color-base-300: oklch(37% 0.013 285.805);
-    --color-base-content: oklch(96% 0.007 247.896);
+    /* Colors (sRGB fallbacks) */
+    --color-base-100: #a5adcf;
+    --color-base-200: #3a3f5f;
+    --color-base-300: #343651;
+    --color-base-content: #f3f6ff;
     --color-primary: #6d5aa5;
-    --color-primary-content: oklch(98% 0.002 247.839);
-    --color-secondary: oklch(59% 0.145 163.225);
-    --color-secondary-content: oklch(98% 0.003 247.858);
-    --color-accent: oklch(71% 0.143 215.221);
-    --color-accent-content: oklch(98% 0.003 247.858);
-    --color-neutral: oklch(52% 0.105 223.128);
-    --color-neutral-content: oklch(98% 0 0);
-    --color-info: oklch(60% 0.126 221.723);
-    --color-info-content: oklch(98% 0.019 200.873);
-    --color-success: oklch(60% 0.118 184.704);
-    --color-success-content: oklch(98% 0.031 120.757);
-    --color-warning: oklch(66% 0.179 58.318);
-    --color-warning-content: oklch(98% 0.022 95.277);
-    --color-error: oklch(58% 0.253 17.585);
-    --color-error-content: oklch(96% 0.015 12.422);
+    --color-primary-content: #f3f6ff;
+    --color-secondary: #5c7ad6;
+    --color-secondary-content: #ffffff;
+    --color-accent: #49a5e5;
+    --color-accent-content: #ffffff;
+    --color-neutral: #4b5d8c;
+    --color-neutral-content: #ffffff;
+    --color-info: #3a9ddc;
+    --color-info-content: #f0f8ff;
+    --color-success: #2f8f58;
+    --color-success-content: #f0fff4;
+    --color-warning: #d79a32;
+    --color-warning-content: #fff6da;
+    --color-error: #c0443b;
+    --color-error-content: #fff2f0;
 
     /* Spacing & Radii */
     --radius-selector: 0.25rem;
@@ -111,6 +111,55 @@
     --border: 1px;
     --depth: 0;
     --noise: 0;
+  }
+
+  @supports (color: oklch(0% 0 0)) {
+    [data-theme="checktick"],
+    [data-theme="checktick-light"] {
+      /* Colors (OKLCH upgrade) */
+      --pc: oklch(98% 0.002 247.839);
+      --s: oklch(59% 0.145 163.225);
+      --sc: oklch(98% 0.003 247.858);
+      --a: oklch(71% 0.143 215.221);
+      --ac: oklch(98% 0.003 247.858);
+      --n: oklch(45% 0.085 224.283);
+      --nc: oklch(98% 0 0);
+      --b1: oklch(98% 0 0);
+      --b2: oklch(96% 0.001 286.375);
+      --b3: oklch(92% 0.004 286.32);
+      --bc: oklch(21% 0.006 285.885);
+      --in: oklch(60% 0.126 221.723);
+      --inc: oklch(98% 0.126 221.723);
+      --su: oklch(60% 0.118 184.704);
+      --suc: oklch(98% 0.031 120.757);
+      --wa: oklch(66% 0.179 58.318);
+      --wac: oklch(98% 0.022 95.277);
+      --er: oklch(58% 0.253 17.585);
+      --erc: oklch(96% 0.015 12.422);
+    }
+
+    [data-theme="checktick-dark"] {
+      /* Colors from your DaisyUI builder output */
+      --color-base-100: oklch(70% 0.04 256.788);
+      --color-base-200: oklch(37% 0.034 259.733);
+      --color-base-300: oklch(37% 0.013 285.805);
+      --color-base-content: oklch(96% 0.007 247.896);
+      --color-primary-content: oklch(98% 0.002 247.839);
+      --color-secondary: oklch(59% 0.145 163.225);
+      --color-secondary-content: oklch(98% 0.003 247.858);
+      --color-accent: oklch(71% 0.143 215.221);
+      --color-accent-content: oklch(98% 0.003 247.858);
+      --color-neutral: oklch(52% 0.105 223.128);
+      --color-neutral-content: oklch(98% 0 0);
+      --color-info: oklch(60% 0.126 221.723);
+      --color-info-content: oklch(98% 0.019 200.873);
+      --color-success: oklch(60% 0.118 184.704);
+      --color-success-content: oklch(98% 0.031 120.757);
+      --color-warning: oklch(66% 0.179 58.318);
+      --color-warning-content: oklch(98% 0.022 95.277);
+      --color-error: oklch(58% 0.253 17.585);
+      --color-error-content: oklch(96% 0.015 12.422);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary\n- add sRGB fallback palette for DaisyUI light and dark themes\n- gate OKLCH values behind @supports (color: oklch()) so capable browsers keep richer palette\n- ensure unsupported browsers render accessible button text colors\n\n## Testing\n- not run