### PR TITLE
Fix: Add missing brand icon environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,11 +5,20 @@ DATABASE_URL=postgres://postgres:postgres@localhost:5432/checktick
 SECURE_SSL_REDIRECT=True # Set to False if not using HTTPS
 CSRF_TRUSTED_ORIGINS=
 BRAND_TITLE=CheckTick
-BRAND_ICON_URL=/static/favicon.ico
-BRAND_THEME=checktick
-BRAND_FONT_HEADING='IBM Plex Mono', ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, 'Apple Color Emoji', 'Segoe UI Emoji'
+BRAND_ICON_URL=/static/icons/checktick_brand_favicon.svg
+BRAND_ICON_URL_DARK=
+BRAND_ICON_ALT=CheckTick
+BRAND_ICON_TITLE=CheckTick
+BRAND_ICON_SIZE_CLASS=w-6 h-6
+BRAND_ICON_SIZE=
+BRAND_THEME=checktick-light
+BRAND_THEME_PRESET_LIGHT=nord
+BRAND_THEME_PRESET_DARK=business
+BRAND_FONT_HEADING='IBM Plex Sans', ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, 'Apple Color Emoji', 'Segoe UI Emoji'
 BRAND_FONT_BODY=Merriweather, ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif
 BRAND_FONT_CSS_URL=https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&family=Merriweather:wght@300;400;700&display=swap
+BRAND_THEME_CSS_LIGHT=
+BRAND_THEME_CSS_DARK=
 # hCaptcha Configuration
 # Get these from https://hcaptcha.com/
 HCAPTCHA_SITEKEY=your_site_key

--- a/.env.selfhost
+++ b/.env.selfhost
@@ -44,14 +44,29 @@ SECURE_SSL_REDIRECT=True
 # Site title shown in browser and header
 BRAND_TITLE=Your Survey Platform
 
-# Theme (currently only 'checktick' available)
-BRAND_THEME=checktick
+# Theme (checktick-light or checktick-dark)
+BRAND_THEME=checktick-light
 
-# Optional: Customize appearance
-# BRAND_ICON_URL=/static/your-logo.ico
+# Icon URLs (optional - can upload via Django admin)
+# BRAND_ICON_URL=/static/icons/checktick_brand_favicon.svg
+# BRAND_ICON_URL_DARK=
+# BRAND_ICON_ALT=Your Survey Platform
+# BRAND_ICON_TITLE=Your Survey Platform
+# BRAND_ICON_SIZE_CLASS=w-6 h-6
+# BRAND_ICON_SIZE=
+
+# Theme presets (daisyUI themes)
+# BRAND_THEME_PRESET_LIGHT=nord
+# BRAND_THEME_PRESET_DARK=business
+
+# Optional: Customize fonts
 # BRAND_FONT_HEADING='Your Font', sans-serif
 # BRAND_FONT_BODY='Your Body Font', serif
 # BRAND_FONT_CSS_URL=https://fonts.googleapis.com/css2?family=...
+
+# Advanced: Custom theme CSS (from daisyUI Theme Generator)
+# BRAND_THEME_CSS_LIGHT=
+# BRAND_THEME_CSS_DARK=
 
 # ========================
 # REQUIRED FOR PRODUCTION: Email Provider
@@ -111,11 +126,3 @@ HCAPTCHA_SECRET=your-secret-key
 # Get your free API key from RCPCH: https://api.rcpch.ac.uk
 EXTERNAL_DATASET_API_URL=https://api.rcpch.ac.uk
 EXTERNAL_DATASET_API_KEY=your-rcpch-api-key-here
-
-# ========================
-# Theme Presets
-# ========================
-# These settings control the default branding and theming of the application
-BRAND_NAME=CheckTick
-BRAND_THEME_PRESET_LIGHT=nord
-BRAND_THEME_PRESET_DARK=business

--- a/checktick_app/settings.py
+++ b/checktick_app/settings.py
@@ -13,6 +13,11 @@ env = environ.Env(
     CSRF_TRUSTED_ORIGINS=(list, []),
     BRAND_TITLE=(str, "CheckTick"),
     BRAND_ICON_URL=(str, ""),  # Empty string falls back to checktick.html component
+    BRAND_ICON_URL_DARK=(str, ""),  # Optional dark mode icon
+    BRAND_ICON_ALT=(str, ""),  # Alt text for icon (defaults to BRAND_TITLE)
+    BRAND_ICON_TITLE=(str, ""),  # Title/tooltip for icon (defaults to BRAND_TITLE)
+    BRAND_ICON_SIZE_CLASS=(str, ""),  # Tailwind size classes (e.g., "w-8 h-8")
+    BRAND_ICON_SIZE=(str, ""),  # Numeric size (e.g., "6" -> "w-6 h-6")
     BRAND_THEME=(str, "checktick-light"),
     BRAND_THEME_PRESET_LIGHT=(
         str,
@@ -34,6 +39,8 @@ env = environ.Env(
         str,
         "https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600;700&family=Merriweather:wght@300;400;700&display=swap",
     ),
+    BRAND_THEME_CSS_LIGHT=(str, ""),  # Custom CSS for light theme
+    BRAND_THEME_CSS_DARK=(str, ""),  # Custom CSS for dark theme
     HCAPTCHA_SITEKEY=(str, ""),
     HCAPTCHA_SECRET=(str, ""),
     # OIDC Configuration
@@ -62,13 +69,20 @@ DATABASES = {
 
 # Branding and theming settings
 BRAND_TITLE = env("BRAND_TITLE")
-BRAND_ICON_URL = env("BRAND_ICON_URL")
+BRAND_ICON_URL = env("BRAND_ICON_URL") or None
+BRAND_ICON_URL_DARK = env("BRAND_ICON_URL_DARK") or None
+BRAND_ICON_ALT = env("BRAND_ICON_ALT") or None
+BRAND_ICON_TITLE = env("BRAND_ICON_TITLE") or None
+BRAND_ICON_SIZE_CLASS = env("BRAND_ICON_SIZE_CLASS") or None
+BRAND_ICON_SIZE = env("BRAND_ICON_SIZE") or None
 BRAND_THEME = env("BRAND_THEME")
 BRAND_THEME_PRESET_LIGHT = env("BRAND_THEME_PRESET_LIGHT")
 BRAND_THEME_PRESET_DARK = env("BRAND_THEME_PRESET_DARK")
 BRAND_FONT_HEADING = env("BRAND_FONT_HEADING")
 BRAND_FONT_BODY = env("BRAND_FONT_BODY")
 BRAND_FONT_CSS_URL = env("BRAND_FONT_CSS_URL")
+BRAND_THEME_CSS_LIGHT = env("BRAND_THEME_CSS_LIGHT") or None
+BRAND_THEME_CSS_DARK = env("BRAND_THEME_CSS_DARK") or None
 
 INSTALLED_APPS = [
     # Use custom AdminConfig to enforce superuser-only access


### PR DESCRIPTION
## Problem

Brand icons were causing 404 errors in the navbar and profile pages when environment variables were not explicitly set. This was due to missing environment variable definitions in `settings.py`.

## Root Cause

Several `BRAND_ICON_*` environment variables documented in the theme system were:
- Not defined in the `environ.Env()` configuration
- Not assigned as settings variables
- Not properly converting empty strings to `None`

This caused the template fallback logic to fail, resulting in 404s when trying to load icons.

## Solution

**Added missing environment variables to `settings.py`:**
- `BRAND_ICON_URL_DARK` - Optional dark mode icon
- `BRAND_ICON_ALT` - Alt text for icon
- `BRAND_ICON_TITLE` - Title/tooltip for icon
- `BRAND_ICON_SIZE_CLASS` - Tailwind size classes
- `BRAND_ICON_SIZE` - Numeric size
- `BRAND_THEME_CSS_LIGHT` - Custom theme CSS for light mode
- `BRAND_THEME_CSS_DARK` - Custom theme CSS for dark mode

**Fixed default handling:**
- Empty strings now convert to `None` using `or None` logic
- Template conditionals properly trigger fallback to `checktick.html` SVG component
- No more 404 errors when icon URLs are not configured

**Updated example configurations:**
- `.env.example` - Corrected `BRAND_ICON_URL` path and added all new variables
- `.env.selfhost` - Comprehensive branding documentation with all options
- Fixed `BRAND_THEME` default from `checktick` to `checktick-light`

## Testing

After this fix, deployments work correctly in three scenarios:
1. **No env vars set** - Falls back to CheckTick SVG icon ✅
2. **Icon URL set** - Uses custom icon ✅
3. **Dark mode icon set** - Switches icons based on theme ✅

## Documentation

All changes align with existing documentation in:
- `docs/branding-and-theme-settings.md`
- `docs/themes.md`
- `docs/self-hosting-themes.md`