### PR TITLE
fix: update seed_nhs_datasets to sync_nhs_dd_datasets in production Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ ENV PORT=8000
 
 EXPOSE 8000
 
-CMD ["sh", "-lc", "python manage.py migrate --noinput && python manage.py seed_nhs_datasets && python manage.py collectstatic --noinput --clear && CSS_HASH=$(md5sum /app/staticfiles/build/styles.css | cut -d' ' -f1) && cp /app/staticfiles/build/styles.css /app/staticfiles/build/styles.$CSS_HASH.css && echo $CSS_HASH > /tmp/css_hash.txt && gunicorn checktick_app.wsgi:application --bind 0.0.0.0:${PORT} --workers 4"]
+CMD ["sh", "-lc", "python manage.py migrate --noinput && python manage.py sync_nhs_dd_datasets && python manage.py collectstatic --noinput --clear && CSS_HASH=$(md5sum /app/staticfiles/build/styles.css | cut -d' ' -f1) && cp /app/staticfiles/build/styles.css /app/staticfiles/build/styles.$CSS_HASH.css && echo $CSS_HASH > /tmp/css_hash.txt && gunicorn checktick_app.wsgi:application --bind 0.0.0.0:${PORT} --workers 4"]

--- a/Dockerfile.registry
+++ b/Dockerfile.registry
@@ -53,4 +53,4 @@ HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/api/health || exit 1
 
 # Default command - build CSS at runtime to ensure fresh styles
-CMD ["sh", "-c", "npm run build:css && python manage.py migrate --noinput && python manage.py seed_nhs_datasets && python manage.py collectstatic --noinput --clear && CSS_HASH=$(md5sum /app/staticfiles/build/styles.css | cut -d' ' -f1) && cp /app/staticfiles/build/styles.css /app/staticfiles/build/styles.$CSS_HASH.css && echo $CSS_HASH > /tmp/css_hash.txt && gunicorn checktick_app.wsgi:application --bind 0.0.0.0:8000 --workers 4"]
+CMD ["sh", "-c", "npm run build:css && python manage.py migrate --noinput && python manage.py sync_nhs_dd_datasets && python manage.py collectstatic --noinput --clear && CSS_HASH=$(md5sum /app/staticfiles/build/styles.css | cut -d' ' -f1) && cp /app/staticfiles/build/styles.css /app/staticfiles/build/styles.$CSS_HASH.css && echo $CSS_HASH > /tmp/css_hash.txt && gunicorn checktick_app.wsgi:application --bind 0.0.0.0:8000 --workers 4"]


### PR DESCRIPTION
## Problem
Production containers were crashing with:
```
Unknown command: 'seed_nhs_datasets'. Did you mean sync_nhs_dd_datasets?
```

## Solution
Updated the CMD in both `Dockerfile` and `Dockerfile.registry` to use the correct command name `sync_nhs_dd_datasets` instead of the deprecated `seed_nhs_datasets`.

## Changes
- Updated `Dockerfile` CMD to use `sync_nhs_dd_datasets`
- Updated `Dockerfile.registry` CMD to use `sync_nhs_dd_datasets`

## Testing
- ✅ Linting passed