### PR TITLE
fix: improve survey publication UX and invite tracking

### DIFF
--- a/checktick_app/surveys/templates/surveys/dashboard.html
+++ b/checktick_app/surveys/templates/surveys/dashboard.html
@@ -72,8 +72,10 @@
   <span class="badge badge-primary badge-outline">{% trans "Visibility" %}: {{ visible }}</span>
   <span class="badge badge-primary badge-outline">{% trans "Window" %}: {{ survey.start_at|default:'—' }} → {{ survey.end_at|default:'—' }}</span>
   <span class="badge badge-primary badge-outline">{% trans "Total responses" %}: {{ total }}{% if survey.max_responses %} / {{ survey.max_responses }}{% endif %}</span>
-  {% if survey.visibility == 'token' %}
-    <a class="badge badge-primary badge-outline hover:bg-primary hover:text-primary-content transition-colors cursor-pointer" href="{% url 'surveys:invites_pending' slug=survey.slug %}">{% trans "Invites" %}: {{ invites_sent }} / {{ total }}</a>
+  {% if survey.visibility == 'token' or survey.visibility == 'authenticated' %}
+    {% if invites_sent > 0 %}
+    <a class="badge badge-primary badge-outline hover:bg-primary hover:text-primary-content transition-colors cursor-pointer" href="{% url 'surveys:invites_pending' slug=survey.slug %}">{% trans "Invites" %}: {{ invites_sent }}{% if invites_pending > 0 %} ({{ invites_pending }} {% trans "pending" %}){% endif %}</a>
+    {% endif %}
   {% endif %}
 </div>
 

--- a/checktick_app/surveys/templates/surveys/invites_pending.html
+++ b/checktick_app/surveys/templates/surveys/invites_pending.html
@@ -1,34 +1,56 @@
 {% extends 'base.html' %}
 {% load i18n %}
-{% block title %}{% trans "Pending invites" %} - {{ survey.name }}{% endblock %}
+{% block title %}{% trans "Survey Invitations" %} - {{ survey.name }}{% endblock %}
 {% block content %}
 <div class="prose">
   {% trans "Surveys" as bc_surveys %}
   {% trans "Survey Dashboard" as bc_survey_dashboard %}
-  {% include 'components/breadcrumbs.html' with crumb1_label=bc_surveys crumb1_href="/surveys/" crumb2_label=bc_survey_dashboard crumb2_href="/surveys/"|add:survey.slug|add:"/dashboard/" %}
-  <h2>{{ survey.name }} — {% trans "Pending invites" %}</h2>
+  {% trans "Invitations" as bc_invitations %}
+  {% include 'components/breadcrumbs.html' with crumb1_label=bc_surveys crumb1_href="/surveys/" crumb2_label=bc_survey_dashboard crumb2_href="/surveys/"|add:survey.slug|add:"/dashboard/" crumb3_label=bc_invitations %}
+  <h2>{{ survey.name }} — {% trans "Invitations" %}</h2>
 </div>
 
 <div class="mt-4">
-  <p class="mb-3">{% blocktrans %}The list below shows invited email addresses that have not yet submitted a response.{% endblocktrans %}</p>
+  <div class="flex flex-wrap gap-2 mb-4">
+    <span class="badge badge-lg badge-outline">{% trans "Total" %}: {{ invites|length }}</span>
+    <span class="badge badge-lg badge-success">{% trans "Completed" %}: {{ completed_count }}</span>
+    <span class="badge badge-lg badge-warning">{% trans "Pending" %}: {{ pending_count }}</span>
+  </div>
+
+  <p class="mb-3 opacity-70">{% blocktrans %}The list below shows all invited email addresses and their completion status.{% endblocktrans %}</p>
   {% if invites %}
     <div class="overflow-x-auto">
       <table class="table w-full">
         <thead>
           <tr>
+            <th>{% trans "Status" %}</th>
             <th>{% trans "Invited at" %}</th>
-            <th>{% trans "Email / Note" %}</th>
-            <th>{% trans "Token" %}</th>
+            <th>{% trans "Email" %}</th>
+            <th>{% trans "Completed at" %}</th>
             <th>{% trans "Actions" %}</th>
           </tr>
         </thead>
         <tbody>
           {% for item in invites %}
-          <tr>
-            <td>{{ item.token.created_at }}</td>
-            <td>{{ item.email }}</td>
-            <td class="font-mono text-xs">{{ item.token.token }}</td>
+          <tr class="{% if item.is_completed %}opacity-60{% endif %}">
             <td>
+              {% if item.is_completed %}
+                <span class="badge badge-success badge-sm">{% trans "Completed" %}</span>
+              {% else %}
+                <span class="badge badge-warning badge-sm">{% trans "Pending" %}</span>
+              {% endif %}
+            </td>
+            <td>{{ item.token.created_at|date:"d M Y H:i" }}</td>
+            <td>{{ item.email }}</td>
+            <td>
+              {% if item.completed_at %}
+                {{ item.completed_at|date:"d M Y H:i" }}
+              {% else %}
+                <span class="opacity-50">—</span>
+              {% endif %}
+            </td>
+            <td>
+              {% if not item.is_completed %}
               <form method="post" action="{% url 'surveys:invite_resend' slug=survey.slug token_id=item.token.id %}" class="inline" onsubmit="return confirm('{% trans "Resend invitation to" %} {{ item.email }}?');">
                 {% csrf_token %}
                 <button type="submit" class="btn btn-xs btn-outline btn-primary">
@@ -38,6 +60,9 @@
                   {% trans "Resend" %}
                 </button>
               </form>
+              {% else %}
+              <span class="opacity-50 text-sm">{% trans "No action needed" %}</span>
+              {% endif %}
             </td>
           </tr>
           {% endfor %}
@@ -45,7 +70,10 @@
       </table>
     </div>
   {% else %}
-    <div class="opacity-60">{% trans "No pending invites found." %}</div>
+    <div class="alert alert-info">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+      <span>{% trans "No invitations have been sent yet. You can send invitations from the publication settings page." %}</span>
+    </div>
   {% endif %}
 
   <p class="mt-4"><a class="btn btn-primary hover:bg-primary-focus transition-colors" href="{% url 'surveys:dashboard' slug=survey.slug %}">{% trans "Back to dashboard" %}</a></p>

--- a/checktick_app/surveys/templates/surveys/publish_settings.html
+++ b/checktick_app/surveys/templates/surveys/publish_settings.html
@@ -43,15 +43,22 @@
                 <span class="link link-hover text-sm">{% trans "What's this?" %}</span>
               </a>
             </label>
-            <select class="select select-bordered w-full" name="visibility" required>
+            <select class="select select-bordered w-full" name="visibility" required {% if survey.status == 'published' %}disabled{% endif %}>
               <option value="authenticated" {% if survey.visibility == 'authenticated' %}selected{% endif %}>{% trans "Authenticated" %}</option>
               <option value="public" {% if survey.visibility == 'public' %}selected{% endif %}>{% trans "Public" %}</option>
               <option value="unlisted" {% if survey.visibility == 'unlisted' %}selected{% endif %}>{% trans "Unlisted" %}</option>
               <option value="token" {% if survey.visibility == 'token' %}selected{% endif %}>{% trans "Invite token" %}</option>
             </select>
+            {% if survey.status == 'published' %}
+            <input type="hidden" name="visibility" value="{{ survey.visibility }}" />
+            <label class="label">
+              <span class="label-text-alt opacity-70">{% trans "Visibility cannot be changed after publishing" %}</span>
+            </label>
+            {% else %}
             <label class="label">
               <span class="label-text-alt opacity-70">{% trans "Who can access this survey" %}</span>
             </label>
+            {% endif %}
           </div>
 
           <div>
@@ -236,6 +243,10 @@
               <div class="flex-1">
                 <label class="{% if not survey.status == 'published' or not survey.no_patient_data_ack %}cursor-pointer{% endif %} flex items-start gap-3">
                   <input type="checkbox" class="checkbox checkbox-warning border-white mt-0.5" name="no_patient_data_ack" id="no_patient_data" {% if survey.no_patient_data_ack %}checked{% endif %} {% if survey.status == 'published' and survey.no_patient_data_ack %}disabled{% endif %} required />
+                  {% if survey.status == 'published' and survey.no_patient_data_ack %}
+                  {# Hidden input to preserve value when checkbox is disabled #}
+                  <input type="hidden" name="no_patient_data_ack" value="on" />
+                  {% endif %}
                   <span class="text-sm">{% blocktrans %}I confirm no <strong>patient-identifiable data</strong> is collected in this survey. This is required when using Public, Unlisted, or Token visibility to prevent unauthorised access.{% endblocktrans %}{% if survey.status == 'published' and survey.no_patient_data_ack %} <span class="text-xs opacity-70">({% trans "Cannot be changed after publication" %})</span>{% endif %}</span>
                 </label>
               </div>

--- a/checktick_app/templates/registration/signup.html
+++ b/checktick_app/templates/registration/signup.html
@@ -201,7 +201,7 @@
         </div>
 
         <div class="mt-3 text-sm text-center">
-          {% trans 'Already have an account?' %} <a class="link" href="{% url 'login' %}">{% trans 'Sign in' %}</a>
+          {% trans 'Already have an account?' %} <a class="link" href="{% url 'login' %}{% if next %}?next={{ next|urlencode }}{% endif %}">{% trans 'Sign in' %}</a>
         </div>
       </div>
     </div>

--- a/docs/publish-and-collection.md
+++ b/docs/publish-and-collection.md
@@ -26,6 +26,7 @@ CheckTick provides four ways to share your survey, from most secure to most open
 **Best for:** Healthcare surveys, research studies, internal assessments
 
 **How it works:**
+
 - Only people with CheckTick accounts can access your survey
 - Participants must log in before completing
 - You can invite specific people by email, or allow any authenticated user
@@ -34,6 +35,7 @@ CheckTick provides four ways to share your survey, from most secure to most open
 **Two access options:**
 
 **Invite-Only Mode** (default):
+
 - Paste email addresses into the invitation box (one per line)
 - Outlook contact format is supported: `John Smith <user@example.com>`
 - System checks if each person has a CheckTick account:
@@ -43,6 +45,7 @@ CheckTick provides four ways to share your survey, from most secure to most open
 - Resend invitations from the dashboard if needed
 
 **Self-Service Mode**:
+
 - Check "Allow any authenticated user to access"
 - Any logged-in user can access the survey
 - No invitation required, but users still need an account
@@ -53,6 +56,7 @@ CheckTick provides four ways to share your survey, from most secure to most open
 **Best for:** Controlled distribution without requiring accounts
 
 **How it works:**
+
 - Generate unique one-time codes for each participant
 - Share links like: `/surveys/your-survey/take/token/ABC123/`
 - Each code works only once
@@ -60,6 +64,7 @@ CheckTick provides four ways to share your survey, from most secure to most open
 - You can set expiry dates and export usage data
 
 **When to use:**
+
 - You want to control who can access the survey
 - You don't need to know participants' identities
 - You want to track individual completion without accounts
@@ -71,12 +76,14 @@ CheckTick provides four ways to share your survey, from most secure to most open
 **Best for:** Semi-private surveys with known audience
 
 **How it works:**
+
 - Get a secret link like: `/surveys/your-survey/take/unlisted/secret-key/`
 - Anyone with the link can complete the survey
 - Link is not discoverable on your site or through the API
 - No account required
 
 **When to use:**
+
 - Sharing with a specific group (e.g., email list, internal team)
 - You trust recipients not to share the link publicly
 - You don't need to track individual access
@@ -88,12 +95,14 @@ CheckTick provides four ways to share your survey, from most secure to most open
 **Best for:** General feedback, public surveys, anonymous data collection
 
 **How it works:**
+
 - Survey is openly accessible at: `/surveys/your-survey/take/`
 - Anyone can complete it without an account
 - Recommended to enable CAPTCHA to prevent spam
 - Rate limiting is automatically enabled
 
 **When to use:**
+
 - Public feedback forms
 - Anonymous surveys where you want maximum participation
 - Non-sensitive data collection
@@ -162,12 +171,14 @@ For details on creating translations, see [Multi-language surveys](/docs/surveys
 When your survey collects patient-identifiable information:
 
 ✅ **Use Authenticated visibility mode**
+
 - Links responses to verified user accounts
 - Provides full audit trail
 - Enables proper data governance
 - Meets healthcare compliance requirements
 
 ❌ **Don't use** Public, Unlisted, or Anonymous Invite Codes
+
 - These modes require confirmation that no patient data is collected
 - System enforces this protection when publishing
 
@@ -192,6 +203,7 @@ Set a maximum number of responses. When reached, the survey automatically closes
 ### Tracking Progress
 
 Your dashboard shows:
+
 - Current status and visibility mode
 - Total responses received
 - Today's responses
@@ -201,6 +213,7 @@ Your dashboard shows:
 ### Managing Invitations (Authenticated & Token modes)
 
 From your dashboard:
+
 - View pending invitations
 - See who has completed the survey
 - Resend invitations to non-responders
@@ -215,6 +228,7 @@ Participants can save their progress and resume later. This is especially helpfu
 ### Completion
 
 After submitting, participants see a customizable thank-you page. You can include:
+
 - Confirmation message
 - Next steps
 - Contact information
@@ -235,12 +249,14 @@ CheckTick includes enterprise-grade security:
 ## Quick Start Guide
 
 **For maximum security (healthcare/research):**
+
 1. Choose **Authenticated** visibility
 2. Leave "Allow any authenticated user" **unchecked**
 3. Paste email addresses to invite
 4. Publish!
 
 **For controlled anonymous surveys:**
+
 1. Choose **Anonymous with Invite Codes**
 2. Generate codes for your participants
 3. Confirm no patient data collected
@@ -248,6 +264,7 @@ CheckTick includes enterprise-grade security:
 5. Publish!
 
 **For public feedback:**
+
 1. Choose **Public** visibility
 2. Confirm no patient data collected
 3. Enable CAPTCHA
@@ -257,21 +274,25 @@ CheckTick includes enterprise-grade security:
 ## Troubleshooting
 
 **"Survey not live"**
+
 - Check status is **Published** (not Draft or Closed)
 - Verify you're within the start/end date window
 - Check if maximum responses has been reached
 
 **"Need to log in" (Authenticated mode)**
+
 - This is correct! Participants need accounts for authenticated surveys
 - New users will be prompted to create an account
 - Invitation emails include clear instructions
 
 **"Invalid or used token"**
+
 - Tokens can only be used once
 - Generate a new token for the participant
 - Check if the token has expired
 
 **"CAPTCHA failed"**
+
 - Ensure CAPTCHA is properly configured (see technical docs)
 - Participant may need to try again
 - Check browser isn't blocking the CAPTCHA widget


### PR DESCRIPTION
## Summary

This PR improves the survey publication workflow and invite tracking functionality.

### Changes

**Publication Settings:**
- Disable visibility dropdown after survey is first published (prevents confusing republish scenarios)
- Add warning message explaining visibility cannot be changed after publication
- Preserve `no_patient_data_ack` checkbox value with hidden input when disabled

**Signup Flow:**
- Fix 'Sign in' link on signup page to preserve `next` parameter for proper redirects

**Invite Tracking:**
- Update invites page to show ALL invites with completion status (not just pending)
- Add summary statistics (total/completed/pending) to invites view
- Show invites badge on dashboard for both token AND authenticated surveys when invites exist
- Only show resend button for pending invites (completed invites just show status)

### Testing
- All 1239 tests pass
- Updated `test_invites_workflow.py` tests for new invite tracking behavior