### PR TITLE
feat: Add QR code generation for survey invitations

### DIFF
--- a/checktick_app/core/email_utils.py
+++ b/checktick_app/core/email_utils.py
@@ -375,6 +375,7 @@ def send_survey_invite_email(
     survey,
     token: str,
     contact_email: Optional[str] = None,
+    qr_code_data_uri: Optional[str] = None,
 ) -> bool:
     """Send survey invitation email with unique token link.
 
@@ -383,6 +384,7 @@ def send_survey_invite_email(
         survey: Survey object
         token: Unique access token string
         contact_email: Optional contact email for questions
+        qr_code_data_uri: Optional QR code as data URI to include in email
 
     Returns:
         True if email sent successfully, False otherwise
@@ -422,6 +424,7 @@ def send_survey_invite_email(
             "end_date": end_date,
             "contact_email": contact_email,
             "brand_title": branding["title"],
+            "qr_code_data_uri": qr_code_data_uri,
         },
     )
 
@@ -436,6 +439,7 @@ def send_survey_invite_email(
             "organization_name": organization_name,
             "end_date": end_date,
             "contact_email": contact_email,
+            "qr_code_data_uri": qr_code_data_uri,
         },
     )
 
@@ -444,6 +448,7 @@ def send_authenticated_survey_invite_existing_user(
     to_email: str,
     survey,
     contact_email: Optional[str] = None,
+    qr_code_data_uri: Optional[str] = None,
 ) -> bool:
     """Send survey invitation to existing authenticated user.
 
@@ -451,6 +456,7 @@ def send_authenticated_survey_invite_existing_user(
         to_email: Recipient email address (existing user)
         survey: Survey object
         contact_email: Optional contact email for questions
+        qr_code_data_uri: Optional QR code as data URI to include in email
 
     Returns:
         True if email sent successfully, False otherwise
@@ -490,6 +496,7 @@ def send_authenticated_survey_invite_existing_user(
             "end_date": end_date,
             "contact_email": contact_email,
             "brand_title": branding["title"],
+            "qr_code_data_uri": qr_code_data_uri,
         },
     )
 
@@ -504,6 +511,7 @@ def send_authenticated_survey_invite_existing_user(
             "organization_name": organization_name,
             "end_date": end_date,
             "contact_email": contact_email,
+            "qr_code_data_uri": qr_code_data_uri,
         },
     )
 
@@ -512,6 +520,7 @@ def send_authenticated_survey_invite_new_user(
     to_email: str,
     survey,
     contact_email: Optional[str] = None,
+    qr_code_data_uri: Optional[str] = None,
 ) -> bool:
     """Send survey invitation to new user (needs to create account).
 
@@ -519,6 +528,7 @@ def send_authenticated_survey_invite_new_user(
         to_email: Recipient email address (no existing account)
         survey: Survey object
         contact_email: Optional contact email for questions
+        qr_code_data_uri: Optional QR code as data URI to include in email
 
     Returns:
         True if email sent successfully, False otherwise
@@ -562,6 +572,7 @@ def send_authenticated_survey_invite_new_user(
             "end_date": end_date,
             "contact_email": contact_email,
             "brand_title": branding["title"],
+            "qr_code_data_uri": qr_code_data_uri,
         },
     )
 
@@ -577,6 +588,7 @@ def send_authenticated_survey_invite_new_user(
             "organization_name": organization_name,
             "end_date": end_date,
             "contact_email": contact_email,
+            "qr_code_data_uri": qr_code_data_uri,
         },
     )
 

--- a/checktick_app/core/qr_utils.py
+++ b/checktick_app/core/qr_utils.py
@@ -1,0 +1,70 @@
+"""
+QR Code utilities for survey invitations.
+
+Generates QR codes for survey links that can be embedded in emails
+and displayed on the publish page.
+"""
+
+import base64
+import io
+import logging
+
+import qrcode
+from qrcode.image.pil import PilImage
+
+logger = logging.getLogger(__name__)
+
+
+def generate_qr_code_base64(url: str, size: int = 200) -> str:
+    """Generate a QR code for a URL and return it as a base64-encoded PNG.
+
+    Args:
+        url: The URL to encode in the QR code
+        size: The size of the QR code in pixels (default 200x200)
+
+    Returns:
+        Base64-encoded PNG image string (without data URI prefix)
+    """
+    try:
+        # Create QR code with appropriate error correction
+        qr = qrcode.QRCode(
+            version=None,  # Auto-determine version based on data
+            error_correction=qrcode.constants.ERROR_CORRECT_M,  # ~15% error correction
+            box_size=10,
+            border=2,
+        )
+        qr.add_data(url)
+        qr.make(fit=True)
+
+        # Generate image
+        img: PilImage = qr.make_image(fill_color="black", back_color="white")
+
+        # Resize to requested size
+        img = img.resize((size, size))
+
+        # Convert to base64
+        buffer = io.BytesIO()
+        img.save(buffer, format="PNG")
+        buffer.seek(0)
+
+        return base64.b64encode(buffer.getvalue()).decode("utf-8")
+
+    except Exception as e:
+        logger.error(f"Failed to generate QR code for URL {url}: {e}")
+        return ""
+
+
+def generate_qr_code_data_uri(url: str, size: int = 200) -> str:
+    """Generate a QR code for a URL and return it as a data URI.
+
+    Args:
+        url: The URL to encode in the QR code
+        size: The size of the QR code in pixels (default 200x200)
+
+    Returns:
+        Data URI string (data:image/png;base64,...) or empty string on error
+    """
+    base64_data = generate_qr_code_base64(url, size)
+    if base64_data:
+        return f"data:image/png;base64,{base64_data}"
+    return ""

--- a/checktick_app/surveys/templates/surveys/dashboard.html
+++ b/checktick_app/surveys/templates/surveys/dashboard.html
@@ -141,12 +141,22 @@
         </svg>
         {% trans "Copy Survey Link" %}
       </button>
+      <button class="btn btn-outline btn-sm flex-shrink-0 show-qr-code" data-url="{{ request.scheme }}://{{ request.get_host }}/surveys/{{ survey.slug }}/take/" title="{% trans 'Show QR Code' %}">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v1m6 11h2m-6 0h-2v4m0-11v3m0 0h.01M12 12h4.01M16 20h4M4 12h4m12 0h.01M5 8h2a1 1 0 001-1V5a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1zm12 0h2a1 1 0 001-1V5a1 1 0 00-1-1h-2a1 1 0 00-1 1v2a1 1 0 001 1zM5 20h2a1 1 0 001-1v-2a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1z" />
+        </svg>
+      </button>
     {% elif survey.visibility == 'unlisted' and survey.unlisted_key %}
       <button class="btn btn-outline btn-sm flex-shrink-0 copy-survey-link" data-slug="{{ survey.slug }}" data-url="{{ request.scheme }}://{{ request.get_host }}/surveys/{{ survey.slug }}/take/unlisted/{{ survey.unlisted_key }}/">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
         </svg>
         {% trans "Copy Survey Link" %}
+      </button>
+      <button class="btn btn-outline btn-sm flex-shrink-0 show-qr-code" data-url="{{ request.scheme }}://{{ request.get_host }}/surveys/{{ survey.slug }}/take/unlisted/{{ survey.unlisted_key }}/" title="{% trans 'Show QR Code' %}">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v1m6 11h2m-6 0h-2v4m0-11v3m0 0h.01M12 12h4.01M16 20h4M4 12h4m12 0h.01M5 8h2a1 1 0 001-1V5a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1zm12 0h2a1 1 0 001-1V5a1 1 0 00-1-1h-2a1 1 0 00-1 1v2a1 1 0 001 1zM5 20h2a1 1 0 001-1v-2a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1z" />
+        </svg>
       </button>
     {% endif %}
   {% endif %}
@@ -607,8 +617,65 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }, 1000);
   }
+
+  // QR Code Modal functionality
+  const qrButtons = document.querySelectorAll('.show-qr-code');
+  const qrModal = document.getElementById('qr_code_modal');
+  const qrImage = document.getElementById('qr_code_image');
+  const qrUrlText = document.getElementById('qr_url_text');
+  const downloadQrBtn = document.getElementById('download_qr_btn');
+
+  qrButtons.forEach(button => {
+    button.addEventListener('click', function(e) {
+      e.preventDefault();
+      const url = this.dataset.url;
+      qrUrlText.textContent = url;
+
+      // Fetch QR code from server
+      fetch('{% url "surveys:get_qr_code" slug=survey.slug %}?url=' + encodeURIComponent(url))
+        .then(response => response.json())
+        .then(data => {
+          if (data.qr_code) {
+            qrImage.src = data.qr_code;
+            downloadQrBtn.onclick = function() {
+              const link = document.createElement('a');
+              link.download = '{{ survey.slug }}-qr-code.png';
+              link.href = data.qr_code;
+              link.click();
+            };
+            qrModal.showModal();
+          }
+        })
+        .catch(error => {
+          console.error('Error fetching QR code:', error);
+        });
+    });
+  });
 });
 </script>
+
+<!-- QR Code Modal -->
+<dialog id="qr_code_modal" class="modal">
+  <div class="modal-box text-center">
+    <h3 class="text-lg font-bold mb-4">{% trans "Survey QR Code" %}</h3>
+    <img id="qr_code_image" src="" alt="{% trans 'QR Code' %}" class="mx-auto mb-4" width="200" height="200" />
+    <p id="qr_url_text" class="text-sm text-base-content/70 break-all mb-4"></p>
+    <div class="modal-action justify-center gap-2">
+      <button id="download_qr_btn" class="btn btn-primary">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+        </svg>
+        {% trans "Download" %}
+      </button>
+      <form method="dialog">
+        <button class="btn">{% trans "Close" %}</button>
+      </form>
+    </div>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button>{% trans "close" %}</button>
+  </form>
+</dialog>
 
 <!-- Edit Title Modal -->
 <dialog id="edit_title_modal" class="modal">

--- a/checktick_app/surveys/templates/surveys/groups.html
+++ b/checktick_app/surveys/templates/surveys/groups.html
@@ -76,7 +76,7 @@
                 <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
                 </svg>
-                {% trans "Publish" %}
+                {% trans "Publish Question Group" %}
               </a>
               {% endif %}
               {% if info.is_repeated %}

--- a/checktick_app/surveys/templates/surveys/invites_pending.html
+++ b/checktick_app/surveys/templates/surveys/invites_pending.html
@@ -26,6 +26,7 @@
             <th>{% trans "Status" %}</th>
             <th>{% trans "Invited at" %}</th>
             <th>{% trans "Email" %}</th>
+            <th>{% trans "QR" %}</th>
             <th>{% trans "Completed at" %}</th>
             <th>{% trans "Actions" %}</th>
           </tr>
@@ -42,6 +43,20 @@
             </td>
             <td>{{ item.token.created_at|date:"d M Y H:i" }}</td>
             <td>{{ item.email }}</td>
+            <td>
+              {% if not item.is_completed %}
+              <button class="btn btn-ghost btn-xs show-invite-qr"
+                      data-url="{{ request.scheme }}://{{ request.get_host }}/surveys/{{ survey.slug }}/take/"
+                      data-email="{{ item.email }}"
+                      title="{% trans 'Show QR Code' %}">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v1m6 11h2m-6 0h-2v4m0-11v3m0 0h.01M12 12h4.01M16 20h4M4 12h4m12 0h.01M5 8h2a1 1 0 001-1V5a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1zm12 0h2a1 1 0 001-1V5a1 1 0 00-1-1h-2a1 1 0 00-1 1v2a1 1 0 001 1zM5 20h2a1 1 0 001-1v-2a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1z" />
+                </svg>
+              </button>
+              {% else %}
+              <span class="opacity-50">—</span>
+              {% endif %}
+            </td>
             <td>
               {% if item.completed_at %}
                 {{ item.completed_at|date:"d M Y H:i" }}
@@ -78,4 +93,74 @@
 
   <p class="mt-4"><a class="btn btn-primary hover:bg-primary-focus transition-colors" href="{% url 'surveys:dashboard' slug=survey.slug %}">{% trans "Back to dashboard" %}</a></p>
 </div>
+
+<!-- QR Code Modal for Authenticated Invites -->
+<dialog id="invite_qr_modal" class="modal">
+  <div class="modal-box text-center">
+    <h3 class="text-lg font-bold mb-4">{% trans "Survey QR Code" %}</h3>
+    <img id="invite_qr_image" src="" alt="{% trans 'QR Code' %}" class="mx-auto mb-4" width="200" height="200" />
+    <p id="invite_qr_url" class="text-sm text-base-content/70 break-all mb-2"></p>
+    <p id="invite_qr_email" class="text-xs text-base-content/50 mb-4"></p>
+    <div class="alert alert-info text-sm mb-4">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current shrink-0 w-5 h-5"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+      <span>{% trans "The user will need to log in with this email address to complete the survey." %}</span>
+    </div>
+    <div class="modal-action justify-center gap-2">
+      <button id="download_invite_qr_btn" class="btn btn-primary btn-sm">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+        </svg>
+        {% trans "Download" %}
+      </button>
+      <form method="dialog">
+        <button class="btn btn-sm">{% trans "Close" %}</button>
+      </form>
+    </div>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button>{% trans "close" %}</button>
+  </form>
+</dialog>
+
+<script nonce="{{ request.csp_nonce }}">
+document.addEventListener('DOMContentLoaded', function() {
+  const qrButtons = document.querySelectorAll('.show-invite-qr');
+  const qrModal = document.getElementById('invite_qr_modal');
+  const qrImage = document.getElementById('invite_qr_image');
+  const qrUrl = document.getElementById('invite_qr_url');
+  const qrEmail = document.getElementById('invite_qr_email');
+  const downloadBtn = document.getElementById('download_invite_qr_btn');
+
+  qrButtons.forEach(button => {
+    button.addEventListener('click', function(e) {
+      e.preventDefault();
+      const url = this.dataset.url;
+      const email = this.dataset.email;
+      qrUrl.textContent = url;
+      qrEmail.textContent = '{% trans "For:" %} ' + email;
+
+      // Fetch QR code from server
+      fetch('{% url "surveys:get_qr_code" slug=survey.slug %}?url=' + encodeURIComponent(url))
+        .then(response => response.json())
+        .then(data => {
+          if (data.qr_code) {
+            qrImage.src = data.qr_code;
+            downloadBtn.onclick = function() {
+              const link = document.createElement('a');
+              // Sanitize email for filename
+              const safeEmail = email.replace(/[^a-zA-Z0-9]/g, '-');
+              link.download = '{{ survey.slug }}-invite-' + safeEmail + '-qr.png';
+              link.href = data.qr_code;
+              link.click();
+            };
+            qrModal.showModal();
+          }
+        })
+        .catch(error => {
+          console.error('Error fetching QR code:', error);
+        });
+    });
+  });
+});
+</script>
 {% endblock %}

--- a/checktick_app/surveys/templates/surveys/publish_settings.html
+++ b/checktick_app/surveys/templates/surveys/publish_settings.html
@@ -210,6 +210,16 @@
           <label class="label">
             <span class="label-text-alt opacity-70">{% trans "Enter one email address per line. Outlook contact format is supported (Name <email@domain.com>)." %}</span>
           </label>
+
+          <div class="form-control mt-4">
+            <label class="cursor-pointer flex items-start gap-3">
+              <input type="checkbox" class="checkbox mt-0.5" name="include_qr_code" checked />
+              <div>
+                <span class="label-text font-medium">{% trans "Include QR code in invitation emails" %}</span>
+                <p class="text-sm opacity-70 mt-1">{% trans "Adds a scannable QR code to the email that links directly to the survey." %}</p>
+              </div>
+            </label>
+          </div>
         </div>
 
         <div class="form-control mb-6" id="allow-any-authenticated-section" style="display: none;">
@@ -418,6 +428,12 @@
     const formData = new FormData();
     formData.append('invite_emails', inviteEmails);
     formData.append('csrfmiddlewaretoken', document.querySelector('[name=csrfmiddlewaretoken]').value);
+
+    // Include QR code checkbox
+    const qrCheckbox = document.querySelector('input[name="include_qr_code"]');
+    if (qrCheckbox && qrCheckbox.checked) {
+      formData.append('include_qr_code', 'on');
+    }
 
     fetch('{% url "surveys:send_invites_async" slug=survey.slug %}', {
       method: 'POST',

--- a/checktick_app/surveys/templates/surveys/tokens.html
+++ b/checktick_app/surveys/templates/surveys/tokens.html
@@ -30,6 +30,7 @@
     <thead>
       <tr>
         <th>{% trans "Token" %}</th>
+        <th>{% trans "QR" %}</th>
         <th>{% trans "Created" %}</th>
         <th>{% trans "Expires" %}</th>
         <th>{% trans "Used" %}</th>
@@ -41,6 +42,16 @@
       {% for t in tokens %}
       <tr>
         <td class="font-mono text-xs">{{ t.token }}</td>
+        <td>
+          <button class="btn btn-ghost btn-xs show-token-qr"
+                  data-url="{{ request.scheme }}://{{ request.get_host }}/surveys/{{ survey.slug }}/take/token/{{ t.token }}/"
+                  data-token="{{ t.token }}"
+                  title="{% trans 'Show QR Code' %}">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v1m6 11h2m-6 0h-2v4m0-11v3m0 0h.01M12 12h4.01M16 20h4M4 12h4m12 0h.01M5 8h2a1 1 0 001-1V5a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1zm12 0h2a1 1 0 001-1V5a1 1 0 00-1-1h-2a1 1 0 00-1 1v2a1 1 0 001 1zM5 20h2a1 1 0 001-1v-2a1 1 0 00-1-1H5a1 1 0 00-1 1v2a1 1 0 001 1z" />
+            </svg>
+          </button>
+        </td>
         <td>{{ t.created_at }}</td>
         <td>{{ t.expires_at }}</td>
         <td>{{ t.used_at }}</td>
@@ -48,9 +59,73 @@
         <td>{{ t.note }}</td>
       </tr>
       {% empty %}
-      <tr><td colspan="6" class="opacity-70">{% trans "No tokens yet." %}</td></tr>
+      <tr><td colspan="7" class="opacity-70">{% trans "No tokens yet." %}</td></tr>
       {% endfor %}
     </tbody>
   </table>
 </div>
+
+<!-- QR Code Modal -->
+<dialog id="token_qr_modal" class="modal">
+  <div class="modal-box text-center">
+    <h3 class="text-lg font-bold mb-4">{% trans "Token QR Code" %}</h3>
+    <img id="token_qr_image" src="" alt="{% trans 'QR Code' %}" class="mx-auto mb-4" width="200" height="200" />
+    <p id="token_qr_url" class="text-sm text-base-content/70 break-all mb-2"></p>
+    <p id="token_qr_token" class="text-xs font-mono text-base-content/50 mb-4"></p>
+    <div class="modal-action justify-center gap-2">
+      <button id="download_token_qr_btn" class="btn btn-primary btn-sm">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+        </svg>
+        {% trans "Download" %}
+      </button>
+      <form method="dialog">
+        <button class="btn btn-sm">{% trans "Close" %}</button>
+      </form>
+    </div>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button>{% trans "close" %}</button>
+  </form>
+</dialog>
+
+<script nonce="{{ request.csp_nonce }}">
+document.addEventListener('DOMContentLoaded', function() {
+  const qrButtons = document.querySelectorAll('.show-token-qr');
+  const qrModal = document.getElementById('token_qr_modal');
+  const qrImage = document.getElementById('token_qr_image');
+  const qrUrl = document.getElementById('token_qr_url');
+  const qrToken = document.getElementById('token_qr_token');
+  const downloadBtn = document.getElementById('download_token_qr_btn');
+
+  qrButtons.forEach(button => {
+    button.addEventListener('click', function(e) {
+      e.preventDefault();
+      const url = this.dataset.url;
+      const token = this.dataset.token;
+      qrUrl.textContent = url;
+      qrToken.textContent = 'Token: ' + token;
+
+      // Fetch QR code from server
+      fetch('{% url "surveys:get_qr_code" slug=survey.slug %}?url=' + encodeURIComponent(url))
+        .then(response => response.json())
+        .then(data => {
+          if (data.qr_code) {
+            qrImage.src = data.qr_code;
+            downloadBtn.onclick = function() {
+              const link = document.createElement('a');
+              link.download = '{{ survey.slug }}-token-' + token + '-qr.png';
+              link.href = data.qr_code;
+              link.click();
+            };
+            qrModal.showModal();
+          }
+        })
+        .catch(error => {
+          console.error('Error fetching QR code:', error);
+        });
+    });
+  });
+});
+</script>
 {% endblock %}

--- a/checktick_app/surveys/urls.py
+++ b/checktick_app/surveys/urls.py
@@ -171,6 +171,11 @@ urlpatterns = [
         name="send_invites_async",
     ),
     path(
+        "<slug:slug>/qr-code/",
+        views.get_qr_code,
+        name="get_qr_code",
+    ),
+    path(
         "<slug:slug>/invites/status/<str:task_id>/",
         views.email_status,
         name="email_status",

--- a/checktick_app/templates/emails/survey_invite.md
+++ b/checktick_app/templates/emails/survey_invite.md
@@ -22,6 +22,15 @@ Or copy and paste this URL into your browser:
 {{ survey_link }}
 ```
 
+{% if qr_code_data_uri %}
+
+### Scan to Complete
+
+You can also scan this QR code with your phone to access the survey:
+
+![QR Code]({{ qr_code_data_uri }})
+{% endif %}
+
 ### Important Notes
 
 ⚠️ **This link can only be used once.** After you submit your response, the link will no longer work.

--- a/checktick_app/templates/emails/survey_invite_authenticated.md
+++ b/checktick_app/templates/emails/survey_invite_authenticated.md
@@ -13,6 +13,12 @@ This survey is being conducted by {{ organization_name }}.
 As an invited participant, please log in to your CheckTick account to access the survey:
 
 [Complete Survey]({{ survey_link }})
+{% if qr_code_data_uri %}
+
+You can also scan this QR code with your phone:
+
+![QR Code]({{ qr_code_data_uri }})
+{% endif %}
 
 {% if end_date %}
 **Please complete by:** {{ end_date }}

--- a/checktick_app/templates/emails/survey_invite_authenticated_new.md
+++ b/checktick_app/templates/emails/survey_invite_authenticated_new.md
@@ -15,6 +15,12 @@ To access this survey, you'll need to create a free CheckTick account. Click the
 [Create Account and Access Survey]({{ signup_link }})
 
 After creating your account, you'll be automatically directed to the survey.
+{% if qr_code_data_uri %}
+
+You can also scan this QR code with your phone to get started:
+
+![QR Code]({{ qr_code_data_uri }})
+{% endif %}
 
 {% if end_date %}
 **Please complete by:** {{ end_date }}

--- a/docs/publish-and-collection.md
+++ b/docs/publish-and-collection.md
@@ -210,6 +210,49 @@ Your dashboard shows:
 - Last 7 days activity
 - Time remaining (if end date is set)
 
+### QR Codes
+
+CheckTick can generate QR codes for your survey links, making it easy to share surveys in printed materials, posters, or presentations.
+
+**QR codes in email invitations:**
+
+When sending invitations (Authenticated or Token modes), you can include a QR code in each email:
+
+1. In the Publish Settings, look for the "Include QR code in invitation emails" checkbox
+2. This is enabled by default
+3. Each recipient gets a unique QR code linking to their survey access
+
+**QR codes on the dashboard:**
+
+For Public and Unlisted surveys, a QR button appears next to the "Copy Survey Link" button:
+
+1. Click the QR icon to view the QR code
+2. Download it as a PNG file
+3. Use it in posters, handouts, or presentations
+
+**QR codes for individual tokens:**
+
+On the Invite Tokens management page, each token has a QR button:
+
+1. Click the QR icon to view the code for that specific token
+2. Download and print for individual distribution
+3. Each QR code is unique to that token
+
+**QR codes for authenticated invites:**
+
+On the Invitations page, pending invitations show a QR button:
+
+1. Click to view the QR code for that invitation
+2. Useful for giving to participants in person
+3. Reminds them to log in with the invited email address
+
+**Best practices:**
+
+- Test the QR code works before printing
+- Include a short URL alongside the QR for accessibility
+- Ensure sufficient size (at least 2cm × 2cm for reliable scanning)
+- Use high contrast printing
+
 ### Managing Invitations (Authenticated & Token modes)
 
 From your dashboard:

--- a/poetry.lock
+++ b/poetry.lock
@@ -317,11 +317,11 @@ description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["main", "dev"]
+markers = "platform_system == \"Windows\" or sys_platform == \"win32\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "platform_system == \"Windows\"", dev = "platform_system == \"Windows\" or sys_platform == \"win32\""}
 
 [[package]]
 name = "commonmark"
@@ -1671,6 +1671,26 @@ files = [
 ]
 
 [[package]]
+name = "qrcode"
+version = "8.2"
+description = "QR Code image generator"
+optional = false
+python-versions = "<4.0,>=3.9"
+groups = ["main"]
+files = [
+    {file = "qrcode-8.2-py3-none-any.whl", hash = "sha256:16e64e0716c14960108e85d853062c9e8bba5ca8252c0b4d0231b9df4060ff4f"},
+    {file = "qrcode-8.2.tar.gz", hash = "sha256:35c3f2a4172b33136ab9f6b3ef1c00260dd2f66f858f24d88418a015f446506c"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+
+[package.extras]
+all = ["pillow (>=9.1.0)", "pypng"]
+pil = ["pillow (>=9.1.0)"]
+png = ["pypng"]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 description = "Python HTTP for Humans."
@@ -2002,4 +2022,4 @@ brotli = ["brotli"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "1700efb405cce19244e9661b0b921e719d7b9f58f0a26d7fdf5446c7010ec891"
+content-hash = "c70c69d70e171cc0a47a27cdfd5c059843be5c3331d4816c316c71486d5316d2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ beautifulsoup4 = "^4.12.0"
 requests = "^2.32.0"
 hvac = "^2.4.0"
 pillow = "^11.0.0"
+qrcode = "^8.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.2"

--- a/tests/test_qr_code.py
+++ b/tests/test_qr_code.py
@@ -1,0 +1,207 @@
+"""Tests for QR code generation functionality."""
+
+from django.test import override_settings
+from django.urls import reverse
+import pytest
+
+from checktick_app.core.qr_utils import generate_qr_code_data_uri
+from checktick_app.surveys.models import Survey
+
+
+class TestQRCodeUtils:
+    """Tests for QR code utility functions."""
+
+    def test_generate_qr_code_returns_data_uri(self):
+        """QR code should return a data URI string."""
+        result = generate_qr_code_data_uri("https://example.com/survey")
+        assert result.startswith("data:image/png;base64,")
+
+    def test_generate_qr_code_different_urls_produce_different_codes(self):
+        """Different URLs should produce different QR codes."""
+        qr1 = generate_qr_code_data_uri("https://example.com/survey1")
+        qr2 = generate_qr_code_data_uri("https://example.com/survey2")
+        assert qr1 != qr2
+
+    def test_generate_qr_code_custom_size(self):
+        """QR codes with different sizes should produce different lengths."""
+        qr_small = generate_qr_code_data_uri("https://example.com", size=100)
+        qr_large = generate_qr_code_data_uri("https://example.com", size=300)
+        # Larger size should produce longer base64 string
+        assert len(qr_large) > len(qr_small)
+
+    def test_generate_qr_code_with_long_url(self):
+        """QR code should handle long URLs."""
+        long_url = "https://example.com/surveys/" + "a" * 100 + "/take/"
+        result = generate_qr_code_data_uri(long_url)
+        assert result.startswith("data:image/png;base64,")
+
+
+@pytest.mark.django_db
+class TestQRCodeView:
+    """Tests for QR code API endpoint."""
+
+    @pytest.fixture
+    def user(self, django_user_model):
+        return django_user_model.objects.create_user(
+            username="testuser", email="test@example.com"
+        )
+
+    @pytest.fixture
+    def survey(self, user):
+        return Survey.objects.create(
+            name="Test Survey",
+            slug="test-survey-qr",
+            owner=user,
+            status="published",
+            visibility="public",
+        )
+
+    def test_qr_code_endpoint_requires_login(self, client, survey):
+        """QR code endpoint should require authentication."""
+        url = reverse("surveys:get_qr_code", kwargs={"slug": survey.slug})
+        response = client.get(
+            url, {"url": f"https://example.com/surveys/{survey.slug}/take/"}
+        )
+        assert response.status_code == 302  # Redirect to login
+
+    @override_settings(SITE_URL="http://testserver")
+    def test_qr_code_endpoint_returns_qr(self, client, user, survey):
+        """QR code endpoint should return QR code data."""
+        client.force_login(user)
+        url = reverse("surveys:get_qr_code", kwargs={"slug": survey.slug})
+        # Use testserver as the host since that's what Django test client uses
+        survey_url = f"http://testserver/surveys/{survey.slug}/take/"
+        response = client.get(url, {"url": survey_url})
+        assert response.status_code == 200
+        data = response.json()
+        assert "qr_code" in data
+        assert data["qr_code"].startswith("data:image/png;base64,")
+
+    def test_qr_code_endpoint_requires_url_param(self, client, user, survey):
+        """QR code endpoint should require URL parameter."""
+        client.force_login(user)
+        url = reverse("surveys:get_qr_code", kwargs={"slug": survey.slug})
+        response = client.get(url)
+        assert response.status_code == 400
+        assert "error" in response.json()
+
+    def test_qr_code_endpoint_validates_survey_url(self, client, user, survey):
+        """QR code endpoint should reject URLs not for this survey."""
+        client.force_login(user)
+        url = reverse("surveys:get_qr_code", kwargs={"slug": survey.slug})
+        # Try to get QR for a different survey
+        response = client.get(
+            url, {"url": "https://example.com/surveys/other-survey/take/"}
+        )
+        assert response.status_code == 400
+        assert "error" in response.json()
+
+    @override_settings(SITE_URL="https://example.com")
+    def test_qr_code_endpoint_rejects_external_urls(self, client, user, survey):
+        """QR code endpoint should reject URLs for external sites."""
+        client.force_login(user)
+        url = reverse("surveys:get_qr_code", kwargs={"slug": survey.slug})
+        # Try to generate QR for an external site (with survey slug in path for bypass attempt)
+        response = client.get(
+            url, {"url": f"https://malicious.com/surveys/{survey.slug}/take/"}
+        )
+        assert response.status_code == 400
+        assert "error" in response.json()
+        assert "site" in response.json()["error"].lower()
+
+    def test_qr_code_endpoint_rejects_invalid_url_format(self, client, user, survey):
+        """QR code endpoint should reject malformed URLs that don't contain survey slug."""
+        client.force_login(user)
+        url = reverse("surveys:get_qr_code", kwargs={"slug": survey.slug})
+        # URLs that don't contain survey slug should be rejected
+        malformed_urls = [
+            "not-a-url",
+            "javascript:alert(1)",
+            "file:///etc/passwd",
+        ]
+        for bad_url in malformed_urls:
+            response = client.get(url, {"url": bad_url})
+            # Should reject as not matching survey slug
+            assert response.status_code == 400
+
+    @pytest.fixture
+    def private_survey(self, user):
+        """Create a private survey for permission testing."""
+        return Survey.objects.create(
+            name="Private Survey",
+            slug="private-survey-qr",
+            owner=user,
+            status="published",
+            visibility="authenticated",  # Requires authentication and permission
+        )
+
+    @override_settings(SITE_URL="http://testserver")
+    def test_qr_code_endpoint_requires_permission(
+        self, client, django_user_model, private_survey
+    ):
+        """QR code endpoint should require view permission on private surveys."""
+        # Create a different user without access
+        other_user = django_user_model.objects.create_user(
+            username="otheruser", email="other@example.com"
+        )
+        client.force_login(other_user)
+        url = reverse("surveys:get_qr_code", kwargs={"slug": private_survey.slug})
+        survey_url = f"http://testserver/surveys/{private_survey.slug}/take/"
+        response = client.get(url, {"url": survey_url})
+        # Should be denied access - 403 Forbidden
+        assert response.status_code == 403
+
+
+@pytest.mark.django_db
+class TestQRCodeInEmails:
+    """Tests for QR code inclusion in invitation emails."""
+
+    @pytest.fixture
+    def user(self, django_user_model):
+        return django_user_model.objects.create_user(
+            username="inviter", email="inviter@example.com"
+        )
+
+    @pytest.fixture
+    def survey(self, user):
+        return Survey.objects.create(
+            name="Email Test Survey",
+            slug="email-test-survey",
+            owner=user,
+            status="published",
+            visibility="token",
+        )
+
+    @override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+    def test_email_with_qr_code(self, user, survey):
+        """Email invitation should include QR code when enabled."""
+        from checktick_app.core.email_utils import send_survey_invite_email
+        from checktick_app.core.qr_utils import generate_qr_code_data_uri
+
+        qr_code = generate_qr_code_data_uri("https://example.com/survey/take/")
+
+        # This should not raise an error
+        result = send_survey_invite_email(
+            to_email="recipient@example.com",
+            survey=survey,
+            token="test-token-123",
+            contact_email=user.email,
+            qr_code_data_uri=qr_code,
+        )
+        # If email sending is properly configured, this should succeed
+        # In test environment with locmem backend, it returns True
+        assert result is True
+
+    @override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
+    def test_email_without_qr_code(self, user, survey):
+        """Email invitation should work without QR code."""
+        from checktick_app.core.email_utils import send_survey_invite_email
+
+        result = send_survey_invite_email(
+            to_email="recipient@example.com",
+            survey=survey,
+            token="test-token-456",
+            contact_email=user.email,
+            qr_code_data_uri=None,
+        )
+        assert result is True


### PR DESCRIPTION
## Summary
Add QR code generation functionality for survey invitations, allowing participants to scan a QR code to access the survey directly.

## Features
- **QR Code in Emails**: Optional checkbox (default checked) on publish form to include QR codes in invitation emails
- **Dashboard QR Button**: QR code button on dashboard for public/unlisted surveys
- **Tokens Page**: QR code column for each token on the tokens management page
- **Invitations Page**: QR code column for authenticated invitations

## Security
- Authentication required for QR generation endpoint
- Permission check for survey access
- Rate limiting (100 requests/hour per user)
- Host validation to prevent QR codes for external URLs
- Survey slug validation

## Technical Details
- Added `qrcode` library dependency
- Created `qr_utils.py` with `generate_qr_code_data_uri` function
- Added `get_qr_code` API endpoint at `/<slug>/qr-code/`
- Updated email templates with conditional QR display

## Tests
- 13 new tests covering utilities, API endpoint, security, and email integration

## Documentation
- Updated `publish-and-collection.md` with QR code feature documentation