### PR TITLE
Expand survey edit modal to support description, update view and JS for live updates

### DIFF
--- a/checktick_app/surveys/templates/surveys/create.html
+++ b/checktick_app/surveys/templates/surveys/create.html
@@ -14,7 +14,7 @@
           {% include "components/form_field.html" with field=form.name label=_("Name") %}
           {% include "components/form_field.html" with field=form.slug label=_("URL Name or 'Slug' (optional)") help=_("If left blank, a slug will be generated from the name.") %}
           {% include "components/form_field.html" with field=form.description label=_("Description") %}
-          <button class="btn btn-primary " type="submit">{% trans "Create survey" %}</button>
+          <button class="btn btn-primary mt-10" type="submit">{% trans "Create survey" %}</button>
         </div>
       </form>
     </div>

--- a/checktick_app/surveys/templates/surveys/dashboard.html
+++ b/checktick_app/surveys/templates/surveys/dashboard.html
@@ -477,10 +477,18 @@ document.addEventListener('DOMContentLoaded', function() {
   const editTitleBtn = document.getElementById('edit-title-btn');
   const titleModal = document.getElementById('edit_title_modal');
   const cancelEditTitleBtn = document.getElementById('cancel_edit_title_btn');
+  const surveyTitleInput = document.getElementById('survey_title_input');
+  const surveyDescriptionInput = document.getElementById('survey_description_input');
+  const saveTitleBtn = document.getElementById('save_title_btn');
+
+
+  // Store the latest values in JS variables
+  let currentSurveyTitle = '{{ survey.name|escapejs }}';
+  let currentSurveyDescription = `{{ survey.description|default_if_none:""|escapejs }}`;
 
   editTitleBtn.addEventListener('click', function() {
-    const currentTitle = '{{ survey.name|escapejs }}';
-    document.getElementById('survey_title_input').value = currentTitle;
+    surveyTitleInput.value = currentSurveyTitle;
+    surveyDescriptionInput.value = currentSurveyDescription;
     titleModal.showModal();
   });
 
@@ -488,36 +496,43 @@ document.addEventListener('DOMContentLoaded', function() {
     titleModal.close();
   });
 
-  document.getElementById('save_title_btn').addEventListener('click', function() {
-    const newTitle = document.getElementById('survey_title_input').value.trim();
+  saveTitleBtn.addEventListener('click', function() {
+    const newTitle = surveyTitleInput.value.trim();
+    const newDescription = surveyDescriptionInput.value.trim();
 
     if (!newTitle) {
       alert('{% trans "Please enter a title" %}');
       return;
     }
 
-    // Save the title
+    // Save the title and description
     fetch('/surveys/{{ survey.slug }}/update-title/', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'X-CSRFToken': '{{ csrf_token }}'
       },
-      body: JSON.stringify({ title: newTitle })
+      body: JSON.stringify({ title: newTitle, description: newDescription })
     })
     .then(response => response.json())
     .then(data => {
       if (data.success) {
         // Update the title in the page
-        document.getElementById('survey-title-display').textContent = newTitle;
-        document.title = '{% trans "Dashboard" %} - ' + newTitle;
+        document.getElementById('survey-title-display').textContent = data.title;
+        document.title = '{% trans "Dashboard" %} - ' + data.title;
+        // Optionally update description display if present
+        const descEl = document.getElementById('survey-description-display');
+        if (descEl) descEl.textContent = data.description;
+        // Update the JS variables so the modal shows the latest value next time
+        currentSurveyTitle = data.title;
+        currentSurveyDescription = data.description || '';
         titleModal.close();
       } else {
-        alert(data.error || '{% trans "Failed to update title" %}');
+        alert(data.error || '{% trans "Failed to update title or description" %}');
       }
     })
     .catch(error => {
-      alert('{% trans "Error updating title" %}');
+      alert('{% trans "Error updating title or description" %}');
       console.error('Error:', error);
     });
   });
@@ -739,13 +754,20 @@ document.addEventListener('DOMContentLoaded', function() {
 <!-- Edit Title Modal -->
 <dialog id="edit_title_modal" class="modal">
   <div class="modal-box">
-    <h3 class="text-lg font-bold">{% trans "Edit Survey Title" %}</h3>
+    <h3 class="text-lg font-bold">{% trans "Edit Survey Title & Description" %}</h3>
 
     <div class="form-control w-full mt-4">
-      <label class="label">
+      <label class="label" for="survey_title_input">
         <span class="label-text">{% trans "Survey Title" %}</span>
       </label>
       <input type="text" id="survey_title_input" class="input input-bordered w-full" maxlength="200" />
+    </div>
+
+    <div class="form-control w-full mt-4">
+      <label class="label" for="survey_description_input">
+        <span class="label-text">{% trans "Description" %}</span>
+      </label>
+      <textarea id="survey_description_input" class="textarea textarea-bordered w-full" maxlength="1000" rows="3"></textarea>
     </div>
 
     <div class="modal-action">

--- a/checktick_app/surveys/views.py
+++ b/checktick_app/surveys/views.py
@@ -2225,14 +2225,23 @@ def update_survey_title(request: HttpRequest, slug: str) -> JsonResponse:
 
         data = json.loads(request.body)
         new_title = data.get("title", "").strip()
+        new_description = data.get("description", None)
+        if new_description is not None:
+            new_description = new_description.strip()
 
         if not new_title:
             return JsonResponse({"success": False, "error": "Title cannot be empty"})
 
         survey.name = new_title
-        survey.save(update_fields=["name"])
+        if new_description is not None:
+            survey.description = new_description
+            survey.save(update_fields=["name", "description"])
+        else:
+            survey.save(update_fields=["name"])
 
-        return JsonResponse({"success": True})
+        return JsonResponse(
+            {"success": True, "title": survey.name, "description": survey.description}
+        )
     except PermissionDenied as e:
         return JsonResponse({"success": False, "error": str(e)}, status=403)
     except Exception as e:


### PR DESCRIPTION
- Expanded the survey edit modal to include a description field alongside the title.
- Updated the JavaScript logic so the modal always shows the latest saved values for both fields, without requiring a page refresh.
- Updated the Django view to save and return the description as well as the title.
- Ensured the modal and dashboard remain in sync after edits.

No breaking changes. Ready for review.