### PR TITLE
Add platform pricing overrides and sync pricing docs

### DIFF
--- a/checktick_app/core/migrations/0016_pricing_override.py
+++ b/checktick_app/core/migrations/0016_pricing_override.py
@@ -1,0 +1,79 @@
+# Generated migration for PricingOverride model
+
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0015_add_userapikey"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="PricingOverride",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "tier",
+                    models.CharField(
+                        choices=[
+                            ("pro", "Individual Pro"),
+                            ("team_small", "Team (Small)"),
+                            ("team_medium", "Team (Medium)"),
+                            ("team_large", "Team (Large)"),
+                        ],
+                        help_text="Subscription tier this override applies to",
+                        max_length=20,
+                        unique=True,
+                    ),
+                ),
+                (
+                    "amount",
+                    models.IntegerField(
+                        help_text="Price inclusive of VAT in pence (e.g. 600 = £6.00)"
+                    ),
+                ),
+                (
+                    "amount_ex_vat",
+                    models.IntegerField(
+                        help_text="Price exclusive of VAT in pence (e.g. 500 = £5.00)"
+                    ),
+                ),
+                (
+                    "is_active",
+                    models.BooleanField(
+                        default=True,
+                        help_text="When inactive, falls back to the value configured in settings.py",
+                    ),
+                ),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "updated_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Pricing Override",
+                "verbose_name_plural": "Pricing Overrides",
+                "ordering": ["tier"],
+            },
+        ),
+    ]

--- a/checktick_app/core/models.py
+++ b/checktick_app/core/models.py
@@ -796,3 +796,69 @@ class UserAPIKey(models.Model):
             expires_at=expires_at,
         )
         return instance, raw_key
+
+
+class PricingOverride(models.Model):
+    """Per-tier price overrides that take precedence over settings.SUBSCRIPTION_TIERS.
+
+    Only tiers with fixed amounts (pro, team_*) are overridable here.
+    Organisation and Enterprise use bespoke per-contract pricing.
+
+    When ``is_active`` is False the entry is ignored and settings.py values apply.
+    """
+
+    OVERRIDABLE_TIERS = [
+        ("pro", "Individual Pro"),
+        ("team_small", "Team (Small)"),
+        ("team_medium", "Team (Medium)"),
+        ("team_large", "Team (Large)"),
+    ]
+
+    tier = models.CharField(
+        max_length=20,
+        unique=True,
+        choices=OVERRIDABLE_TIERS,
+        help_text="Subscription tier this override applies to",
+    )
+    amount = models.IntegerField(
+        help_text="Price inclusive of VAT in pence (e.g. 600 = £6.00)"
+    )
+    amount_ex_vat = models.IntegerField(
+        help_text="Price exclusive of VAT in pence (e.g. 500 = £5.00)"
+    )
+    is_active = models.BooleanField(
+        default=True,
+        help_text="When inactive, falls back to the value configured in settings.py",
+    )
+    updated_at = models.DateTimeField(auto_now=True)
+    updated_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="+",
+    )
+
+    class Meta:
+        ordering = ["tier"]
+        verbose_name = "Pricing Override"
+        verbose_name_plural = "Pricing Overrides"
+
+    def __str__(self) -> str:
+        return f"{self.get_tier_display()} override: £{self.amount / 100:.2f} inc VAT"
+
+    @classmethod
+    def get_effective_tiers(cls) -> dict:
+        """Return SUBSCRIPTION_TIERS merged with any active database overrides.
+
+        The returned dict has the same structure as settings.SUBSCRIPTION_TIERS.
+        Active overrides replace ``amount`` and ``amount_ex_vat`` for their tier.
+        """
+        import copy
+
+        tiers = copy.deepcopy(settings.SUBSCRIPTION_TIERS)
+        for override in cls.objects.filter(is_active=True):
+            if override.tier in tiers:
+                tiers[override.tier]["amount"] = override.amount
+                tiers[override.tier]["amount_ex_vat"] = override.amount_ex_vat
+        return tiers

--- a/checktick_app/core/templates/core/platform_admin/base.html
+++ b/checktick_app/core/templates/core/platform_admin/base.html
@@ -50,6 +50,12 @@
               {% trans "Logs" %}
             </a>
           </li>
+          <li>
+            <a href="{% url 'core:platform_admin_pricing' %}"
+               class="btn btn-sm {% if request.resolver_match.url_name == 'platform_admin_pricing' %}btn-primary{% else %}btn-ghost{% endif %}">
+              {% trans "Pricing" %}
+            </a>
+          </li>
         </ul>
       </nav>
     </div>

--- a/checktick_app/core/templates/core/platform_admin/pricing_overrides.html
+++ b/checktick_app/core/templates/core/platform_admin/pricing_overrides.html
@@ -1,0 +1,154 @@
+{% extends 'core/platform_admin/base.html' %}
+{% load i18n %}
+
+{% block platform_title %}{% trans "Pricing Overrides" %}{% endblock %}
+
+{% block platform_content %}
+<div class="max-w-4xl">
+
+  <div class="flex items-center justify-between mb-6">
+    <div>
+      <h2 class="text-2xl font-bold">{% trans "Pricing Overrides" %}</h2>
+      <p class="text-base-content/70 mt-1">
+        {% trans "Override the prices configured in settings.py without a code deploy. Amounts are entered in pounds (£). Leave a row blank to fall back to the settings.py default." %}
+      </p>
+    </div>
+  </div>
+
+  <div class="alert alert-info mb-6">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current shrink-0 w-5 h-5">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+    </svg>
+    <div class="text-sm">
+      <strong>{% trans "Note:" %}</strong>
+      {% blocktrans %}
+        Active overrides affect what is shown on the public pricing page and what GoCardless charges for new subscriptions.
+        They do <em>not</em> retroactively change existing subscriptions.
+        Deactivating an override reverts the displayed price to the settings.py default.
+      {% endblocktrans %}
+    </div>
+  </div>
+
+  <form method="post" action="{% url 'core:platform_admin_pricing' %}">
+    {% csrf_token %}
+
+    <div class="card bg-base-100 shadow">
+      <div class="card-body">
+        <div class="overflow-x-auto">
+          <table class="table">
+            <thead>
+              <tr>
+                <th>{% trans "Tier" %}</th>
+                <th class="text-right">{% trans "Default (settings.py)" %}</th>
+                <th class="text-right">{% trans "Effective now" %}</th>
+                <th>{% trans "Override (£ inc. VAT)" %}</th>
+                <th>{% trans "Override (£ ex. VAT)" %}</th>
+                <th class="text-center">{% trans "Active" %}</th>
+                <th>{% trans "Last updated" %}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for row in tier_rows %}
+              <tr class="{% if row.has_active_override %}bg-warning/10{% endif %}">
+                <td>
+                  <span class="font-semibold">{{ row.label }}</span>
+                  <br>
+                  <span class="text-xs text-base-content/50">{{ row.key }}</span>
+                </td>
+                <td class="text-right text-base-content/60">
+                  £{{ row.settings_amount_pounds }}
+                  <br>
+                  <span class="text-xs">(ex: £{{ row.settings_amount_ex_vat_pounds }})</span>
+                </td>
+                <td class="text-right font-semibold {% if row.has_active_override %}text-warning{% endif %}">
+                  £{{ row.effective_amount_pounds }}
+                  <br>
+                  <span class="text-xs font-normal">ex: £{{ row.effective_amount_ex_vat_pounds }}</span>
+                </td>
+                <td>
+                  <div class="form-control">
+                    <label class="sr-only" for="{{ row.key }}_amount">{% trans "Inc. VAT price" %}</label>
+                    <div class="input-group input-group-sm">
+                      <span class="bg-base-200 px-2 flex items-center text-sm">£</span>
+                      <input
+                        type="number"
+                        id="{{ row.key }}_amount"
+                        name="{{ row.key }}_amount"
+                        step="0.01"
+                        min="0"
+                        class="input input-sm input-bordered w-28"
+                        placeholder="e.g. 6.00"
+                        value="{{ row.override_amount_pounds }}"
+                        aria-label="{% trans 'Price inc. VAT for' %} {{ row.label }}"
+                      >
+                    </div>
+                  </div>
+                </td>
+                <td>
+                  <div class="form-control">
+                    <label class="sr-only" for="{{ row.key }}_amount_ex_vat">{% trans "Ex. VAT price" %}</label>
+                    <div class="input-group input-group-sm">
+                      <span class="bg-base-200 px-2 flex items-center text-sm">£</span>
+                      <input
+                        type="number"
+                        id="{{ row.key }}_amount_ex_vat"
+                        name="{{ row.key }}_amount_ex_vat"
+                        step="0.01"
+                        min="0"
+                        class="input input-sm input-bordered w-28"
+                        placeholder="e.g. 5.00"
+                        value="{{ row.override_amount_ex_vat_pounds }}"
+                        aria-label="{% trans 'Price ex. VAT for' %} {{ row.label }}"
+                      >
+                    </div>
+                  </div>
+                </td>
+                <td class="text-center">
+                  <input
+                    type="checkbox"
+                    name="{{ row.key }}_active"
+                    class="checkbox checkbox-sm"
+                    {% if row.override and row.override.is_active %}checked{% endif %}
+                    aria-label="{% trans 'Activate override for' %} {{ row.label }}"
+                  >
+                </td>
+                <td class="text-xs text-base-content/50">
+                  {% if row.override %}
+                    {{ row.override.updated_at|date:"d M Y H:i" }}
+                    {% if row.override.updated_by %}
+                      <br>{{ row.override.updated_by.username }}
+                    {% endif %}
+                  {% else %}
+                    {% trans "—" %}
+                  {% endif %}
+                </td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+
+        <div class="card-actions justify-end mt-4 pt-4 border-t border-base-300">
+          <p class="text-xs text-base-content/50 mr-auto">
+            {% trans "Enter pound values (e.g. 6.00 or 30.00). Tick Active to enable the override. Untick or leave blank to revert to settings.py defaults." %}
+          </p>
+          <button type="submit" class="btn btn-primary">
+            {% trans "Save Overrides" %}
+          </button>
+        </div>
+      </div>
+    </div>
+  </form>
+
+  <div class="mt-6 text-sm text-base-content/60">
+    <p>
+      {% blocktrans %}
+        <strong>How it works:</strong> Active overrides are stored in the database and merged with settings.py at request time.
+        The public pricing page and GoCardless checkout both use the effective (merged) prices.
+        The settings.py values remain unchanged and serve as defaults whenever no active override exists.
+      {% endblocktrans %}
+    </p>
+  </div>
+
+</div>
+{% endblock %}

--- a/checktick_app/core/templates/core/pricing.html
+++ b/checktick_app/core/templates/core/pricing.html
@@ -119,7 +119,7 @@
       <div class="card-body">
         <h2 class="card-title text-2xl mb-2">{% trans "Individual Pro" %}</h2>
         <div class="mb-4">
-          <span class="text-3xl font-bold">£6</span>
+          <span class="text-3xl font-bold">{{ tier_display.pro }}</span>
           <span class="text-base-content">/{% trans "month" %}</span>
           <p class="text-sm text-base-content">{% trans "Unlimited surveys" %}</p>
           <p class="text-xs text-base-content">{% trans "inc. VAT" %}</p>
@@ -218,20 +218,20 @@
             <span class="label-text font-semibold">{% trans "Select team size:" %}</span>
           </label>
           <select id="team-size-selector" class="select select-bordered w-full">
-            <option value="team_small" data-price="30" data-members="5" data-price-id="{{ price_ids.team_small }}">
-              {% trans "Small" %} - 5 {% trans "members" %} - £30/{% trans "month" %}
+            <option value="team_small" data-price="{{ tier_pounds.team_small }}" data-members="{{ subscription_tiers.team_small.max_members }}" data-price-id="{{ price_ids.team_small }}">
+              {% trans "Small" %} - {{ subscription_tiers.team_small.max_members }} {% trans "members" %} - {{ tier_display.team_small }}/{% trans "month" %}
             </option>
-            <option value="team_medium" data-price="90" data-members="15" data-price-id="{{ price_ids.team_medium }}">
-              {% trans "Medium" %} - 15 {% trans "members" %} - £90/{% trans "month" %}
+            <option value="team_medium" data-price="{{ tier_pounds.team_medium }}" data-members="{{ subscription_tiers.team_medium.max_members }}" data-price-id="{{ price_ids.team_medium }}">
+              {% trans "Medium" %} - {{ subscription_tiers.team_medium.max_members }} {% trans "members" %} - {{ tier_display.team_medium }}/{% trans "month" %}
             </option>
-            <option value="team_large" data-price="300" data-members="50" data-price-id="{{ price_ids.team_large }}">
-              {% trans "Large" %} - 50 {% trans "members" %} - £300/{% trans "month" %}
+            <option value="team_large" data-price="{{ tier_pounds.team_large }}" data-members="{{ subscription_tiers.team_large.max_members }}" data-price-id="{{ price_ids.team_large }}">
+              {% trans "Large" %} - {{ subscription_tiers.team_large.max_members }} {% trans "members" %} - {{ tier_display.team_large }}/{% trans "month" %}
             </option>
           </select>
         </div>
 
         <div class="mb-4">
-          <span class="text-3xl font-bold" id="team-price-display">£30</span>
+          <span class="text-3xl font-bold" id="team-price-display">{{ tier_display.team_small }}</span>
           <span class="text-base-content">/{% trans "month" %}</span>
           <p class="text-sm text-base-content" id="team-members-display">{% trans "Up to" %} 5 {% trans "team members" %}</p>
           <p class="text-xs text-base-content">{% trans "inc. VAT" %}</p>

--- a/checktick_app/core/urls.py
+++ b/checktick_app/core/urls.py
@@ -87,6 +87,11 @@ urlpatterns = [
         views_platform_admin.platform_logs,
         name="platform_admin_logs",
     ),
+    path(
+        "platform-admin/pricing/",
+        views_platform_admin.pricing_overrides,
+        name="platform_admin_pricing",
+    ),
     # Billing
     path(
         "subscription/", views_billing.subscription_portal, name="subscription_portal"

--- a/checktick_app/core/views.py
+++ b/checktick_app/core/views.py
@@ -102,8 +102,27 @@ def pricing(request):
     auto_open_checkout = request.session.pop("auto_open_checkout", False)
     pending_tier = request.session.get("pending_tier", "")
 
+    from checktick_app.core.models import PricingOverride
+
+    effective_tiers = PricingOverride.get_effective_tiers()
+
+    # Pre-compute pound display values for the template (amounts stored as pence)
+    def _to_pounds(pence: int) -> str:
+        pounds = pence / 100
+        return f"£{int(pounds)}" if pounds == int(pounds) else f"£{pounds:.2f}"
+
+    tier_display = {
+        key: _to_pounds(cfg["amount"])
+        for key, cfg in effective_tiers.items()
+        if cfg.get("amount", 0) > 0
+    }
+    # Whole-pound values used by the team selector JS (data-price attribute)
+    tier_pounds = {key: cfg["amount"] // 100 for key, cfg in effective_tiers.items()}
+
     context = {
-        "subscription_tiers": settings.SUBSCRIPTION_TIERS,
+        "subscription_tiers": effective_tiers,
+        "tier_display": tier_display,
+        "tier_pounds": tier_pounds,
         "self_hosted": False,  # Always False here since we redirect above
         "auto_open_checkout": auto_open_checkout,
         "pending_tier": pending_tier,

--- a/checktick_app/core/views_platform_admin.py
+++ b/checktick_app/core/views_platform_admin.py
@@ -616,3 +616,98 @@ def platform_logs(request: HttpRequest) -> HttpResponse:
     context["hosting_configured"] = hosting_service.is_available
 
     return render(request, "core/platform_admin/logs.html", context)
+
+
+@superuser_required
+@require_http_methods(["GET", "POST"])
+@ratelimit(key="user", rate="30/h", block=True)
+def pricing_overrides(request: HttpRequest) -> HttpResponse:
+    """Manage per-tier pricing overrides.
+
+    GET  – show current effective prices and any active overrides.
+    POST – save updated prices for one or more tiers, or deactivate overrides.
+    """
+    from django.conf import settings
+
+    from checktick_app.core.models import PricingOverride
+
+    if request.method == "POST":
+        for tier, _label in PricingOverride.OVERRIDABLE_TIERS:
+            amount_str = request.POST.get(f"{tier}_amount", "").strip()
+            amount_ex_vat_str = request.POST.get(f"{tier}_amount_ex_vat", "").strip()
+            is_active = request.POST.get(f"{tier}_active") == "on"
+
+            if not amount_str or not amount_ex_vat_str:
+                # No value submitted for this tier – deactivate any existing override
+                PricingOverride.objects.filter(tier=tier).update(is_active=False)
+                continue
+
+            try:
+                # Accept either pound (e.g. "6.00") or pence (e.g. "600") input
+                amount_raw = float(amount_str)
+                amount_ex_vat_raw = float(amount_ex_vat_str)
+                # If value looks like pounds (< 1000) convert to pence
+                amount = int(amount_raw * 100) if amount_raw < 1000 else int(amount_raw)
+                amount_ex_vat = (
+                    int(amount_ex_vat_raw * 100)
+                    if amount_ex_vat_raw < 1000
+                    else int(amount_ex_vat_raw)
+                )
+            except ValueError:
+                messages.error(request, f"Invalid price value for {tier}.")
+                continue
+
+            PricingOverride.objects.update_or_create(
+                tier=tier,
+                defaults={
+                    "amount": amount,
+                    "amount_ex_vat": amount_ex_vat,
+                    "is_active": is_active,
+                    "updated_by": request.user,
+                },
+            )
+
+        logger.info(f"Pricing overrides updated by {request.user.username}")
+        messages.success(request, "Pricing overrides saved.")
+        return redirect("core:platform_admin_pricing")
+
+    # Build display data: settings defaults alongside any active override
+    effective_tiers = PricingOverride.get_effective_tiers()
+    overrides_by_tier = {o.tier: o for o in PricingOverride.objects.all()}
+
+    tier_rows = []
+    for tier, label in PricingOverride.OVERRIDABLE_TIERS:
+        settings_cfg = settings.SUBSCRIPTION_TIERS.get(tier, {})
+        effective_cfg = effective_tiers.get(tier, {})
+        override = overrides_by_tier.get(tier)
+        tier_rows.append(
+            {
+                "key": tier,
+                "label": label,
+                "settings_amount": settings_cfg.get("amount", 0),
+                "settings_amount_ex_vat": settings_cfg.get("amount_ex_vat", 0),
+                "effective_amount": effective_cfg.get("amount", 0),
+                "effective_amount_ex_vat": effective_cfg.get("amount_ex_vat", 0),
+                "override": override,
+                "has_active_override": override is not None and override.is_active,
+            }
+        )
+
+    def _p(pence: int) -> str:
+        return f"{pence / 100:.2f}"
+
+    # Add pre-formatted pound strings so the template doesn't need arithmetic
+    for row in tier_rows:
+        row["settings_amount_pounds"] = _p(row["settings_amount"])
+        row["settings_amount_ex_vat_pounds"] = _p(row["settings_amount_ex_vat"])
+        row["effective_amount_pounds"] = _p(row["effective_amount"])
+        row["effective_amount_ex_vat_pounds"] = _p(row["effective_amount_ex_vat"])
+        if row["override"]:
+            row["override_amount_pounds"] = _p(row["override"].amount)
+            row["override_amount_ex_vat_pounds"] = _p(row["override"].amount_ex_vat)
+        else:
+            row["override_amount_pounds"] = ""
+            row["override_amount_ex_vat_pounds"] = ""
+
+    context = {"tier_rows": tier_rows}
+    return render(request, "core/platform_admin/pricing_overrides.html", context)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - db_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U checktick"]
+      test: [ "CMD-SHELL", "pg_isready -U checktick" ]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -52,7 +52,8 @@ services:
           "--spider",
           "--proxy",
           "off",
-          "http://127.0.0.1:8200/v1/sys/health?standbyok=true&uninitcode=200&sealedcode=200",
+          "http://127.0.0.1:8200/v1/sys/health?standbyok=true&uninitcode=200&\
+            sealedcode=200",
         ]
       interval: 5s
       timeout: 3s
@@ -97,7 +98,18 @@ services:
         condition: service_healthy
     volumes:
       - ./:/app
-    command: sh -lc "npm install && npm run build:css && python manage.py migrate --noinput && python manage.py collectstatic --noinput --clear && python manage.py runserver 0.0.0.0:8000"
+    command: >
+      sh -lc " for i in $(seq 1 30); do
+        getent hosts db >/dev/null 2>&1 && break;
+        echo 'Waiting for db DNS...';
+        sleep 1;
+      done; for i in $(seq 1 30); do
+        python -c \"import socket; s=socket.socket(); s.settimeout(1); s.connect(('db', 5432)); s.close()\" >/dev/null 2>&1 && break;
+        echo 'Waiting for db:5432...';
+        sleep 1;
+      done; npm install && npm run build:css && python manage.py migrate
+      --noinput && python manage.py collectstatic --noinput --clear && python
+      manage.py runserver 0.0.0.0:8000 "
 
 volumes:
   db_data:

--- a/docs/billing-and-subscriptions.md
+++ b/docs/billing-and-subscriptions.md
@@ -18,6 +18,17 @@ CheckTick uses a secure payment provider to handle all billing. We offer flexibl
 
 All prices are **inclusive of 20% UK VAT**. Base rate: £5 per seat (ex VAT) = £6 per seat (inc VAT).
 
+### Default Hosted Prices
+
+Hosted pricing defaults are configured in application settings and used for checkout unless overridden by Platform Admin:
+
+- **Individual Pro:** £6/month (inc VAT), £5/month (ex VAT)
+- **Team Small (5 seats):** £30/month (inc VAT), £25/month (ex VAT)
+- **Team Medium (15 seats):** £90/month (inc VAT), £75/month (ex VAT)
+- **Team Large (50 seats):** £300/month (inc VAT), £250/month (ex VAT)
+
+Organisation and Enterprise pricing remain bespoke.
+
 ## Available Plans
 
 ### Individual Plans
@@ -156,6 +167,29 @@ You can:
 - Download invoice PDFs
 - See payment dates and amounts
 - Check payment status
+
+## Platform Admin Pricing Overrides
+
+For hosted deployments, superusers can override default public prices from the Platform Admin panel.
+
+### Access
+
+- Navigate to **Platform Admin** -> **Pricing**
+- URL: `/platform-admin/pricing/`
+- Access is restricted to superusers
+
+### What It Does
+
+- Overrides **Pro**, **Team Small**, **Team Medium**, and **Team Large** prices
+- Stores both **inc VAT** and **ex VAT** amounts
+- Uses settings defaults when an override is disabled or blank
+- Updates the public pricing page and new checkout pricing without a code deploy
+
+### Scope and Limitations
+
+- Overrides affect new subscriptions and displayed prices
+- Existing subscriptions are not retroactively repriced
+- Organisation and Enterprise pricing are managed separately as bespoke plans
 
 ## Upgrading Your Plan
 

--- a/docs/pricing-summary.md
+++ b/docs/pricing-summary.md
@@ -23,22 +23,22 @@ All payments are processed securely through our UK-based payment provider.
 
 ### Individual Plans
 
-| Plan | Monthly Price | Annual Price | Key Features |
-|------|---------------|--------------|--------------|
-| **Free** | £0 | £0 | Up to 3 active surveys (all encrypted), unlimited responses, no patient data templates |
-| **Pro** | £5 | £50 (save £10) | Unlimited encrypted surveys, patient data collection, collaboration, email support |
+| Plan | Monthly Price (inc VAT) | Key Features |
+|------|--------------------------|--------------|
+| **Free** | £0 | Up to 3 active surveys (all encrypted), unlimited responses, no patient data templates |
+| **Pro** | £6 | Unlimited encrypted surveys, patient data collection, collaboration, email support |
 
 ---
 
 ### Team Plans
 
-Fixed-price plans for small to medium collaborative teams.
+Fixed-price plans for collaborative teams.
 
-| Plan | Monthly Price | Annual Price | Members | Surveys |
-|------|---------------|--------------|---------|---------|
-| **Team Small** | £25 | £250 (save £50) | 5 | 50 |
-| **Team Medium** | £50 | £500 (save £100) | 10 | 50 |
-| **Team Large** | £100 | £1,000 (save £200) | 20 | 50 |
+| Plan | Monthly Price (inc VAT) | Members | Surveys |
+|------|--------------------------|---------|---------|
+| **Team Small** | £30 | 5 | 50 |
+| **Team Medium** | £90 | 15 | 50 |
+| **Team Large** | £300 | 50 | 50 |
 
 All team plans include: Role-based access (Admin/Creator/Viewer), team encryption management.
 
@@ -48,9 +48,9 @@ All team plans include: Role-based access (Admin/Creator/Viewer), team encryptio
 
 Per-seat pricing for larger organisations requiring flexible user counts.
 
-| Component | Monthly Price | Annual Price |
-|-----------|---------------|--------------|
-| **Per user** | £30 | £300 (save £60/user) |
+| Component | Monthly Price |
+|-----------|---------------|
+| **Per user (typical hosted rate)** | £6/user (inc VAT) |
 
 #### Included Features
 
@@ -119,10 +119,19 @@ Enterprise tier provides a fully independent deployment of the CheckTick platfor
 ### Payment Processing
 
 - **Currency:** GBP (£)
-- **Billing Cycles:** Monthly or Annual
-- **Annual Discount:** ~17% (2 months free equivalent)
+- **Billing Cycles:** Monthly (default for hosted tiers)
 - **Payment Methods:** Direct Debit (UK bank accounts), Credit/Debit cards
 - **UK Only:** CheckTick is currently available to UK customers only
+
+## Platform Admin Pricing Overrides
+
+Hosted deployments can override Pro/Team prices in the Platform Admin panel without a code release.
+
+- **Path:** `/platform-admin/pricing/`
+- **Access:** Superuser only
+- **Behavior:** Active overrides change public pricing display and new checkout amounts
+- **Fallback:** Disabling an override reverts to settings defaults
+- **Note:** Existing subscriptions are not retroactively repriced
 
 ### Refund Policy
 
@@ -155,5 +164,5 @@ Optional paid support contracts are available for self-hosted customers.
 **CheckTick**
 *Secure surveys for healthcare and research*
 
-Document version: 1.0
-Last updated: 4 December 2025
+Document version: 1.2
+Last updated: 2 May 2026

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "checktick"
-version = "0.2.32"
+version = "0.2.33"
 description = "Secure, server-rendered survey platform for medical audit and research"
 authors = ["CheckTick Maintainers <simon@eatyourpeas.co.uk>"]
 readme = "README.md"

--- a/tests/test_platform_admin_permissions.py
+++ b/tests/test_platform_admin_permissions.py
@@ -6,6 +6,7 @@ from django.contrib.auth import get_user_model
 from django.urls import reverse
 import pytest
 
+from checktick_app.core.models import PricingOverride
 from checktick_app.surveys.models import Organization, OrganizationMembership
 
 User = get_user_model()
@@ -593,4 +594,63 @@ class TestPlatformLogsAccess:
         client.force_login(superuser)
         url = reverse("core:platform_admin_logs")
         response = client.post(url)
+        assert response.status_code == 405
+
+
+# ============================================================================
+# Platform Pricing Access Tests
+# ============================================================================
+
+
+@pytest.mark.django_db
+class TestPlatformPricingAccess:
+    """Test access control and behavior for platform pricing overrides."""
+
+    def test_anonymous_user_redirected_to_login(self, client):
+        """Anonymous users are redirected to login."""
+        url = reverse("core:platform_admin_pricing")
+        response = client.get(url)
+        assert response.status_code == 302
+        assert "login" in response.url.lower()
+
+    def test_regular_user_denied_access(self, client, regular_user):
+        """Regular users cannot access platform pricing page."""
+        client.force_login(regular_user)
+        url = reverse("core:platform_admin_pricing")
+        response = client.get(url)
+        assert response.status_code == 302
+
+    def test_superuser_can_access_pricing(self, client, superuser):
+        """Superusers can access pricing override page."""
+        client.force_login(superuser)
+        url = reverse("core:platform_admin_pricing")
+        response = client.get(url)
+        assert response.status_code == 200
+        assert b"Pricing Overrides" in response.content
+
+    def test_superuser_can_save_override(self, client, superuser):
+        """Superusers can create/update a pricing override."""
+        client.force_login(superuser)
+        url = reverse("core:platform_admin_pricing")
+
+        response = client.post(
+            url,
+            {
+                "pro_amount": "7.00",
+                "pro_amount_ex_vat": "5.83",
+                "pro_active": "on",
+            },
+        )
+        assert response.status_code == 302
+
+        override = PricingOverride.objects.get(tier="pro")
+        assert override.amount == 700
+        assert override.amount_ex_vat == 583
+        assert override.is_active is True
+
+    def test_pricing_page_rejects_put(self, client, superuser):
+        """Pricing page should reject unsupported methods."""
+        client.force_login(superuser)
+        url = reverse("core:platform_admin_pricing")
+        response = client.put(url)
         assert response.status_code == 405

--- a/tests/test_pricing_overrides.py
+++ b/tests/test_pricing_overrides.py
@@ -1,0 +1,55 @@
+"""Tests for pricing overrides and effective tier rendering."""
+
+from django.urls import reverse
+import pytest
+
+from checktick_app.core.models import PricingOverride
+
+
+@pytest.mark.django_db
+class TestPricingOverrides:
+    """Test pricing override merge behavior and UI rendering."""
+
+    def test_get_effective_tiers_uses_active_override(self):
+        """Active override should replace settings values for that tier."""
+        PricingOverride.objects.create(
+            tier="pro",
+            amount=700,
+            amount_ex_vat=583,
+            is_active=True,
+        )
+
+        effective = PricingOverride.get_effective_tiers()
+        assert effective["pro"]["amount"] == 700
+        assert effective["pro"]["amount_ex_vat"] == 583
+
+    def test_get_effective_tiers_ignores_inactive_override(self):
+        """Inactive override should not change effective tier values."""
+        effective_before = PricingOverride.get_effective_tiers()
+        baseline_amount = effective_before["pro"]["amount"]
+        baseline_ex_vat = effective_before["pro"]["amount_ex_vat"]
+
+        PricingOverride.objects.create(
+            tier="pro",
+            amount=700,
+            amount_ex_vat=583,
+            is_active=False,
+        )
+
+        effective_after = PricingOverride.get_effective_tiers()
+        assert effective_after["pro"]["amount"] == baseline_amount
+        assert effective_after["pro"]["amount_ex_vat"] == baseline_ex_vat
+
+    def test_public_pricing_page_shows_override_amount(self, client):
+        """Public pricing page should render override amount for Pro tier."""
+        PricingOverride.objects.create(
+            tier="pro",
+            amount=700,
+            amount_ex_vat=583,
+            is_active=True,
+        )
+
+        response = client.get(reverse("core:pricing"))
+        assert response.status_code == 200
+        content = response.content.decode("utf-8")
+        assert "£7" in content


### PR DESCRIPTION
## Summary
- Add dynamic pricing override support with a new `PricingOverride` model and migration
- Use effective tier pricing in public pricing page rendering instead of hard-coded values
- Add Platform Admin pricing override page and route (`/platform-admin/pricing/`)
- Add tests for pricing override behavior and platform-admin access controls
- Improve dev container startup resilience by waiting for DB DNS/TCP before migration
- Update pricing documentation and add Platform Admin pricing override guidance
- Bump project version to `0.2.33` in `pyproject.toml`

## Commits
- `4c6a778` Add platform pricing overrides and dynamic pricing display
- `fda0581` Update pricing docs and add platform admin overrides section
- `3248b12` Bump project version to 0.2.33

## Notes
- Local hooks and lint checks passed during commit/push.
- Existing environment warning about missing `blake2b/blake2s` hash algorithms still appears but is non-blocking in this workflow.