### PR TITLE
docs: clarify OIDC encryption — no passphrase required for patient data surveys (v0.2.39)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,10 @@ It signposts common workflows and links to the full docs instead of duplicating 
 - If the Docker web container is not running, the script will start it automatically.
 - Accessibility tests require a separate environment and should not be part of the default local validation path.
 
-### 2. Run tests without Docker
+### 2. Test fallback when Docker is not running
 
-- Use `s/test --no-a11y --host-fallback` to run locally via Poetry, bypassing Docker entirely.
+- If the Docker web container is not running, the script will start it automatically.
+- `s/test --no-a11y --host-fallback` runs via Poetry on the host, but **requires a local PostgreSQL instance on port 5432**. The Docker DB is not exposed to the host, so this will fail unless you have a separate local DB. The script will check and exit clearly if none is found.
 
 ### 3. Lint before commit
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 	<img alt="CheckTick" src="checktick_app/static/icons/CheckTick_long-03.svg">
 </picture>
 
-![Version](https://img.shields.io/badge/version-0.2.38-5fcfdd?style=for-the-badge)
+![Version](https://img.shields.io/badge/version-0.2.39-5fcfdd?style=for-the-badge)
 ![GitHub License](https://img.shields.io/github/license/eatyourpeas/checktick?style=for-the-badge&color=5fcfdd)
 ![OpenAPI](https://img.shields.io/badge/OpenAPI-3.0-5fcfdd?style=for-the-badge&logo=openapiinitiative&logoColor=white)
 ![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/eatyourpeas/checktick?style=for-the-badge&color=5fcfdd)

--- a/checktick_app/core/tests/test_password_reset_flow.py
+++ b/checktick_app/core/tests/test_password_reset_flow.py
@@ -2,19 +2,18 @@ import re
 import secrets
 
 from django.contrib.auth.models import User
-from django.core import mail
 from django.urls import reverse
 import pytest
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 class TestPasswordResetFlow:
     def test_password_reset_pages_render(self, client):
         assert client.get(reverse("password_reset")).status_code == 200
         assert client.get(reverse("password_reset_done")).status_code == 200
         assert client.get(reverse("password_reset_complete")).status_code == 200
 
-    def test_request_reset_sends_email(self, client):
+    def test_request_reset_sends_email(self, client, mailoutbox):
         # Generate passwords and unique identifiers at runtime to avoid conflicts in parallel tests
         initial_password = secrets.token_urlsafe(12)
         new_password = secrets.token_urlsafe(16)
@@ -30,8 +29,8 @@ class TestPasswordResetFlow:
         assert resp.status_code == 302
         assert resp.url == reverse("password_reset_done")
         # Email sent
-        assert len(mail.outbox) == 1
-        msg = mail.outbox[0]
+        assert len(mailoutbox) == 1
+        msg = mailoutbox[0]
         assert "Reset your password" in msg.subject
         # Ensure an HTML alternative is present and includes the CTA button.
         assert msg.alternatives, "Expected HTML alternative email"

--- a/checktick_app/surveys/tests/test_oidc_encryption.py
+++ b/checktick_app/surveys/tests/test_oidc_encryption.py
@@ -13,7 +13,7 @@ from django.test import Client, TestCase
 from django.urls import reverse
 
 from checktick_app.core.models import UserOIDC
-from checktick_app.surveys.models import Survey
+from checktick_app.surveys.models import QuestionGroup, Survey
 
 User = get_user_model()
 TEST_PASSWORD = "x"
@@ -150,6 +150,41 @@ class TestOIDCEncryption(TestCase):
         # Test OIDC unlock
         oidc_kek = self.survey.unlock_with_oidc(self.user)
         assert oidc_kek == kek
+
+    def test_oidc_auto_unlock_on_patient_data_survey(self):
+        """OIDC users can auto-unlock patient data surveys without a passphrase.
+
+        SSO providers enforce MFA/conditional access at the IdP level, which is
+        considered sufficient. A separate passphrase is not required and is not
+        enforced by the application.
+        """
+        # Create a survey with a patient data question group
+        patient_group = QuestionGroup.objects.create(
+            name="Patient Details",
+            owner=self.user,
+            schema={
+                "template": "patient_details_encrypted",
+                "fields": ["first_name", "last_name", "nhs_number", "date_of_birth"],
+            },
+        )
+        patient_survey = Survey.objects.create(
+            name="Patient OIDC Survey",
+            slug="patient-oidc-survey",
+            owner=self.user,
+            status=Survey.Status.DRAFT,
+        )
+        patient_survey.question_groups.add(patient_group)
+
+        # Confirm it detects patient data
+        assert patient_survey.collects_patient_data() is True
+
+        kek = os.urandom(32)
+        patient_survey.set_oidc_encryption(kek, self.user)
+
+        # OIDC auto-unlock should work regardless of patient data content
+        assert patient_survey.can_user_unlock_automatically(self.user) is True
+        unlocked_kek = patient_survey.unlock_with_oidc(self.user)
+        assert unlocked_kek == kek
 
 
 class TestOIDCEncryptionViews(TestCase):

--- a/checktick_app/surveys/tests/test_whole_response_encryption.py
+++ b/checktick_app/surveys/tests/test_whole_response_encryption.py
@@ -96,25 +96,33 @@ class TestSurveyPatientDataDetection:
 
 @pytest.mark.django_db
 class TestSSOPassphraseRequirement:
-    """Test SSO passphrase requirement for patient data surveys."""
+    """
+    Tests for the sso_user_needs_passphrase model helper.
 
-    def test_default_requires_passphrase_for_patient_data(
+    Note: this flag (require_passphrase_for_patient_data) is not enforced in the
+    application. OIDC users can auto-unlock all surveys, including patient data
+    surveys, without a passphrase. Enterprise SSO providers enforce MFA and
+    conditional access at the IdP level, which is considered sufficient protection.
+    These tests document the model's behaviour only.
+    """
+
+    def test_passphrase_flag_defaults_true_but_is_not_enforced(
         self, survey_with_patient_data
     ):
-        """By default, patient data surveys require passphrase for SSO users."""
+        """require_passphrase_for_patient_data defaults True but is not enforced by views."""
         assert survey_with_patient_data.require_passphrase_for_patient_data is True
+        # sso_user_needs_passphrase() reflects the flag, but the unlock view does
+        # not call it — OIDC auto-unlock proceeds regardless.
         assert survey_with_patient_data.sso_user_needs_passphrase() is True
 
-    def test_can_disable_passphrase_requirement(self, survey_with_patient_data):
-        """Organizations can disable passphrase requirement if security policy permits."""
+    def test_flag_can_be_set_false(self, survey_with_patient_data):
+        """The flag can be set False (has no functional effect currently)."""
         survey_with_patient_data.require_passphrase_for_patient_data = False
         survey_with_patient_data.save()
         assert survey_with_patient_data.sso_user_needs_passphrase() is False
 
-    def test_non_patient_survey_no_passphrase_requirement(
-        self, survey_without_patient_data
-    ):
-        """Non-patient surveys don't require passphrase for SSO users."""
+    def test_non_patient_survey_returns_false(self, survey_without_patient_data):
+        """Non-patient surveys always return False."""
         assert survey_without_patient_data.sso_user_needs_passphrase() is False
 
 

--- a/docs/encryption-for-users.md
+++ b/docs/encryption-for-users.md
@@ -10,14 +10,14 @@ CheckTick protects your sensitive survey data with encryption. This guide explai
 
 ## Quick Overview
 
-| Subscription Tier | Encryption Features | Recovery Options |
-|-------------------|---------------------|------------------|
-| **Free** | **All surveys encrypted** (no patient data templates) | Password OR Recovery Phrase OR **Verified Identity Recovery** |
-| **Individual** | Password + Recovery Phrase + **Platform Key Escrow** | Password OR Recovery Phrase OR **Verified Identity Recovery** |
-| **Pro** | Enhanced encryption + Vault backup | Password OR Recovery Phrase OR **Verified Identity Recovery** |
-| **Team Small/Medium/Large** | Team-shared keys + Organisation master key | Team admin OR Organisation admin OR Platform recovery |
-| **Organisation** | Hierarchical encryption + Admin recovery | Organisation admin OR **Platform recovery** |
-| **Enterprise** | Custom encryption + Dedicated Vault | Custom recovery procedures + Platform recovery |
+| Subscription Tier           | Encryption Features                                   | Recovery Options                                              |
+| --------------------------- | ----------------------------------------------------- | ------------------------------------------------------------- |
+| **Free**                    | **All surveys encrypted** (no patient data templates) | Password OR Recovery Phrase OR **Verified Identity Recovery** |
+| **Individual**              | Password + Recovery Phrase + **Platform Key Escrow**  | Password OR Recovery Phrase OR **Verified Identity Recovery** |
+| **Pro**                     | Enhanced encryption + Vault backup                    | Password OR Recovery Phrase OR **Verified Identity Recovery** |
+| **Team Small/Medium/Large** | Team-shared keys + Organisation master key            | Team admin OR Organisation admin OR Platform recovery         |
+| **Organisation**            | Hierarchical encryption + Admin recovery              | Organisation admin OR **Platform recovery**                   |
+| **Enterprise**              | Custom encryption + Dedicated Vault                   | Custom recovery procedures + Platform recovery                |
 
 ## The Important Promise
 
@@ -212,15 +212,15 @@ Everything in Individual tier, plus:
 
 ### Differences from Individual
 
-| Feature | Individual | Pro |
-|---------|-----------|-----|
-| Basic encryption | ✅ | ✅ |
-| Platform recovery | ✅ | ✅ |
-| Verification time | 24-48 hours | 12-24 hours |
-| Time delay | 24-48 hours | 24 hours (faster) |
-| Audit retention | 1 year | 2 years |
-| Compliance reports | ❌ | ✅ |
-| Dedicated support | ❌ | ✅ |
+| Feature            | Individual  | Pro               |
+| ------------------ | ----------- | ----------------- |
+| Basic encryption   | ✅          | ✅                |
+| Platform recovery  | ✅          | ✅                |
+| Verification time  | 24-48 hours | 12-24 hours       |
+| Time delay         | 24-48 hours | 24 hours (faster) |
+| Audit retention    | 1 year      | 2 years           |
+| Compliance reports | ❌          | ✅                |
+| Dedicated support  | ❌          | ✅                |
 
 ---
 
@@ -273,15 +273,15 @@ Teams can operate in two modes:
 
 #### SSO and Patient Data Surveys
 
-**Important**: When a survey collects patient data, SSO auto-unlock alone is not sufficient.
+SSO auto-unlock works for **all** surveys, including those that collect patient data. No separate passphrase is required.
 
-Even with SSO, you'll be asked to set a **passphrase** when your survey includes patient demographics (NHS number, date of birth, names, etc.). This adds an extra layer of protection:
+When a survey contains patient demographics (NHS number, date of birth, names, etc.), the entire response is encrypted and automatically unlocked when you sign in via your SSO provider. This is considered sufficient protection because:
 
-- **Why**: Patient data requires explicit intent to access - it shouldn't unlock "automatically" when you log in
-- **How**: You set a passphrase the first time you publish a patient data survey
-- **Using**: Enter your passphrase to unlock the survey (in addition to being signed in via SSO)
+- Enterprise SSO providers (Microsoft Azure AD, Google Workspace) enforce multi-factor authentication, conditional access, and device compliance at the organisational level
+- CheckTick's OIDC key derivation uses the same cryptographic strength as password-based encryption (PBKDF2, 100,000 iterations, unique per-user salt)
+- Requiring a passphrase on top of SSO introduces a meaningful risk of clinicians losing access to patient data — an outcome worse than the marginal security gain
 
-This ensures that even if your SSO session is compromised, patient data remains protected.
+If you prefer an additional recovery mechanism, you can opt in to **SSO + Recovery Phrase** when setting up encryption. This is optional and recommended only for users who want a manual fallback independent of their SSO provider.
 
 #### Whole Survey Encryption
 
@@ -407,6 +407,7 @@ Organisation owners have access to a recovery management dashboard:
 - 🔐 Dual authorization workflow
 
 **Example dashboard view:**
+
 ```
 ┌─────────────────────────────────────────────────────────┐
 │ Recovery Requests                              [Filter] │

--- a/docs/oidc-sso-setup.md
+++ b/docs/oidc-sso-setup.md
@@ -205,17 +205,21 @@ When unlocking a survey:
 ### User Experience
 
 **For OIDC Users:**
+
 - Create survey → Automatic encryption setup
-- Access survey → Automatic unlock (no manual key entry)
+- Access survey → Automatic unlock (no manual key entry), including surveys that collect patient data
 - Green success message: "Survey automatically unlocked with your Google/Microsoft account"
+- Optional: choose SSO + Recovery Phrase during encryption setup for a manual fallback
 
 **For Traditional Users:**
+
 - Standard password/recovery phrase workflow unchanged
 - Can upgrade to OIDC authentication to gain automatic unlock
 
 ### Security Model
 
 **Key Derivation:**
+
 ```
 OIDC Key = PBKDF2(
     provider:subject,    # "google:12345" or "azure:user@hospital.org"
@@ -225,12 +229,14 @@ OIDC Key = PBKDF2(
 ```
 
 **Encryption Flow:**
+
 1. Survey KEK encrypts all patient data
 2. KEK is encrypted with OIDC-derived key
 3. Encrypted KEK stored in `survey.encrypted_kek_oidc`
 4. User's salt stored in `UserOIDC.key_derivation_salt`
 
 **Access Control:**
+
 - Only the exact OIDC identity can decrypt
 - Provider + subject must match exactly
 - Different providers/accounts cannot cross-decrypt
@@ -238,17 +244,20 @@ OIDC Key = PBKDF2(
 ### Implementation Details
 
 **Model Changes:**
+
 - `Survey.encrypted_kek_oidc`: OIDC-encrypted survey key
 - `Survey.has_oidc_encryption()`: Check if OIDC unlock available
 - `Survey.unlock_with_oidc(user)`: Automatic unlock method
 - `UserOIDC.key_derivation_salt`: Unique salt per OIDC user
 
 **View Integration:**
+
 - `survey_create`: Automatically adds OIDC encryption for SSO users
 - `survey_unlock`: Attempts automatic unlock before manual methods
 - Audit logging for all unlock methods including OIDC
 
 **Template Updates:**
+
 - Automatic unlock notification for OIDC users
 - Visual indicators for encryption methods available
 - Fallback UI for manual unlock when needed
@@ -256,16 +265,19 @@ OIDC Key = PBKDF2(
 ### Migration and Compatibility
 
 **Existing Surveys:**
+
 - Continue to work with password/recovery phrase
 - OIDC encryption can be added retroactively
 - No disruption to existing workflows
 
 **Mixed Authentication:**
+
 - Users can have both OIDC and password authentication
 - All unlock methods work independently
 - Users can switch between authentication types
 
 **Backward Compatibility:**
+
 - Traditional encryption fully preserved
 - API endpoints unchanged
 - Existing integrations unaffected

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "checktick"
-version = "0.2.38"
+version = "0.2.39"
 description = "Secure, server-rendered survey platform for medical audit and research"
 authors = ["CheckTick Maintainers <simon@eatyourpeas.co.uk>"]
 readme = "README.md"

--- a/s/test
+++ b/s/test
@@ -77,7 +77,7 @@ while [[ $# -gt 0 ]]; do
             echo ""
             echo "Execution Options:"
             echo "  --serial      Run tests serially (no parallelization)"
-            echo "  --host-fallback  Run locally via Poetry instead of Docker (skip container)"
+            echo "  --host-fallback  Run locally via Poetry instead of Docker (requires local DB on port 5432)"
             echo "  --coverage    Generate coverage report"
             echo ""
             echo "Examples:"
@@ -143,6 +143,18 @@ if [ "$HOST_FALLBACK" = true ]; then
     else
         echo "⚠️  Poetry is not available. Falling back to local Python environment." >&2
     fi
+    # Warn early if no local DB is reachable (the DB port is not exposed from Docker)
+    if ! nc -z localhost 5432 2>/dev/null; then
+        echo "⚠️  No database found at localhost:5432." >&2
+        echo "   --host-fallback requires a local PostgreSQL instance running on the host." >&2
+        echo "   The Docker database is not exposed to the host — start the web container" >&2
+        echo "   and omit --host-fallback to run tests inside Docker instead." >&2
+        exit 1
+    fi
+elif ! docker info >/dev/null 2>&1; then
+    echo "❌ Docker daemon is not running." >&2
+    echo "   Start Docker Desktop, or run: $0 --host-fallback [other flags]" >&2
+    exit 1
 elif docker compose ps --status running --services 2>/dev/null | grep -q '^web$'; then
     # Container already up
     EXEC_PREFIX=(docker compose exec web)


### PR DESCRIPTION
## Summary

Corrects inaccurate documentation stating that OIDC/SSO users must set a passphrase when a survey collects patient data. The code does not enforce this, and by design it should not.

### Why no passphrase is needed for OIDC users

- Enterprise IdPs (Azure AD, Google Workspace) enforce MFA, conditional access, and device compliance at the organisational level
- CheckTick's OIDC key derivation uses PBKDF2 with 100,000 iterations and a unique per-user salt — equivalent strength to password-based encryption
- Requiring a passphrase on top of SSO introduces a meaningful risk of clinicians losing access to patient data, which outweighs the marginal security gain
- The passphrase requirement exists in the model (`require_passphrase_for_patient_data`, `sso_user_needs_passphrase()`) but has never been enforced in the views or templates

## Changes

### Documentation
- `docs/encryption-for-users.md`: rewrites the *SSO and Patient Data Surveys* section — removes the passphrase requirement, explains the rationale, notes SSO + Recovery Phrase as an optional opt-in
- `docs/oidc-sso-setup.md`: updates the *User Experience* section to reflect that patient data surveys auto-unlock for OIDC users

### Tests
- Adds `test_oidc_auto_unlock_on_patient_data_survey`: explicitly proves OIDC users can unlock patient data surveys without a passphrase
- Rewrites `TestSSOPassphraseRequirement`: tests now document that the model flag is **not enforced** rather than giving false confidence it is

### Tooling
- `s/test`: exits clearly if Docker daemon is not running; exits with a helpful message if `--host-fallback` is used without a reachable local DB on port 5432
- `AGENTS.md`: updated to reflect the `--host-fallback` DB requirement

## Test results
23/23 tests passing in `test_oidc_encryption.py` and `test_whole_response_encryption.py`.