### PR TITLE
fix: declare ARG TARGETARCH in Dockerfile.registry for multi-platform builds

### DIFF
--- a/Dockerfile.registry
+++ b/Dockerfile.registry
@@ -19,7 +19,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN pip install --no-cache-dir poetry==${POETRY_VERSION}
 
 # Install sct binary (SNOMED CT toolchain) — pre-built release, no Rust needed
-# TARGETARCH is set automatically by Docker BuildKit for multi-platform builds
+# TARGETARCH must be declared to expose the BuildKit automatic platform ARG to RUN steps
+ARG TARGETARCH
 ARG SCT_VERSION=v0.3.11
 ARG SCT_REPO=pacharanero/sct
 RUN set -eux; \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "checktick"
-version = "0.4.0"
+version = "0.4.1"
 description = "Secure, server-rendered survey platform for medical audit and research"
 authors = ["CheckTick Maintainers <simon@eatyourpeas.co.uk>"]
 readme = "README.md"


### PR DESCRIPTION
## Problem

The Docker build failed with:

```
/bin/sh: 1: TARGETARCH: parameter not set
```

Docker BuildKit's automatic platform ARGs (`TARGETARCH`, `TARGETOS`, etc.) must be explicitly declared with `ARG` before they are accessible in `RUN` steps. Without the declaration the shell sees `TARGETARCH` as unset, causing the `case` statement to fail.

## Fix

Added `ARG TARGETARCH` immediately before the `RUN` block in `Dockerfile.registry` that uses it.

## Version

Patch bump: `0.4.0` → `0.4.1`