### PR TITLE
fix: redirect sct TMPDIR to mounted volume to prevent container eviction

### DIFF
--- a/checktick_app/surveys/management/commands/update_snomed_db.py
+++ b/checktick_app/surveys/management/commands/update_snomed_db.py
@@ -195,6 +195,12 @@ class Command(BaseCommand):
                 )
                 return
 
+            # Redirect TMPDIR to the mounted volume so that sct's intermediate
+            # files (ndjson extraction, SQLite build) do not fill the container's
+            # ephemeral storage and trigger an eviction/OOM kill.
+            tmp_dir = str(Path(data_dir) / "tmp")
+            Path(tmp_dir).mkdir(parents=True, exist_ok=True)
+
             download_result = subprocess.run(
                 [
                     "sct",
@@ -209,7 +215,13 @@ class Command(BaseCommand):
                     "--pipeline",
                 ],
                 text=True,
-                env={**os.environ, "TRUD_API_KEY": trud_api_key},
+                env={
+                    **os.environ,
+                    "TRUD_API_KEY": trud_api_key,
+                    "TMPDIR": tmp_dir,
+                    "TEMP": tmp_dir,
+                    "TMP": tmp_dir,
+                },
             )
 
             if download_result.returncode != 0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "checktick"
-version = "0.4.1"
+version = "0.4.2"
 description = "Secure, server-rendered survey platform for medical audit and research"
 authors = ["CheckTick Maintainers <simon@eatyourpeas.co.uk>"]
 readme = "README.md"


### PR DESCRIPTION
## Problem

When `update_snomed_db` ran `sct trud download --pipeline` (which internally runs `sct ndjson` to extract the SNOMED CT zip), the `sct` binary used the system default `/tmp` for intermediate extraction files. On Northflank, container ephemeral storage is limited (~1 GB regardless of the RAM tier). The 580 MB SNOMED CT zip expands to several GB of RF2 files during extraction, exhausting ephemeral storage and triggering pod eviction (exit code 255 / container restart).

## Fix

Before the `subprocess.run` call, create a `tmp/` directory inside the persistent `snomed-data` volume (`/app/data/tmp`) and pass it as `TMPDIR`, `TMP`, and `TEMP` in the subprocess environment. This routes all `sct` intermediate file I/O to the volume rather than ephemeral container storage.

```python
tmp_dir = str(Path(data_dir) / "tmp")
Path(tmp_dir).mkdir(parents=True, exist_ok=True)

subprocess.run(
    ["sct", "trud", "download", ...],
    env={
        **os.environ,
        "TRUD_API_KEY": trud_api_key,
        "TMPDIR": tmp_dir,
        "TEMP": tmp_dir,
        "TMP": tmp_dir,
    },
)
```

## Testing

After deploying, run `python manage.py update_snomed_db` from the web service console. The SNOMED CT zip is already present at `/app/data/uk_sct2mo_42.1.0_20260506000001Z.zip` (SHA-256 verified from a previous attempt), so the download step will be skipped and extraction will proceed immediately.

Bumps version `0.4.1` → `0.4.2`.