### PR TITLE
fix: pin npm deps, revert SCT repo, bump to 0.4.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,8 @@ RUN poetry config virtualenvs.create false \
     && poetry install --only main --no-interaction --no-ansi --no-root
 
 # Build CSS
-COPY package.json ./
-RUN npm install --no-audit --no-fund
+COPY package.json package-lock.json ./
+RUN npm ci --no-audit --no-fund
 
 COPY checktick_app ./checktick_app
 COPY manage.py ./
@@ -46,7 +46,7 @@ COPY docs ./docs
 COPY CONTRIBUTING.md ./
 # Install the current project now that sources are present
 RUN poetry install --only main --no-interaction --no-ansi
-RUN npm run build:css
+RUN NODE_OPTIONS=--max-old-space-size=384 npm run build:css
 
 RUN adduser --disabled-login --gecos "" appuser
 RUN mkdir -p /app/staticfiles /app/media && \

--- a/Dockerfile.registry
+++ b/Dockerfile.registry
@@ -22,7 +22,7 @@ RUN pip install --no-cache-dir poetry==${POETRY_VERSION}
 # TARGETARCH must be declared to expose the BuildKit automatic platform ARG to RUN steps
 ARG TARGETARCH
 ARG SCT_VERSION=v0.3.11
-ARG SCT_REPO=eatyourpeas/sct
+ARG SCT_REPO=pacharanero/sct
 RUN set -eux; \
     case "$TARGETARCH" in \
     amd64)  SCT_ARCH="x86_64" ;; \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "checktick"
-version = "0.4.3"
+version = "0.4.4"
 description = "Secure, server-rendered survey platform for medical audit and research"
 authors = ["CheckTick Maintainers <simon@eatyourpeas.co.uk>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

Three related fixes bundled together:

- **Dockerfile**: use `npm ci` + `package-lock.json` for reproducible CSS builds; cap Node heap at 384 MB with `NODE_OPTIONS` to prevent OOM kills during `tailwindcss` compilation
- **Dockerfile.registry**: revert `SCT_REPO` back to `pacharanero/sct` — the `eatyourpeas` fork has no published release binaries, causing `curl` 404 (exit code 22) in CI
- **pyproject.toml**: bump patch version to `0.4.4`

> Note: the x86_64 SNOMED parsing fix will be submitted as a PR to the upstream `pacharanero/sct` maintainer.