### PR TITLE
fix: move CSS build to image build step to prevent OOM crash at startup

### DIFF
--- a/Dockerfile.registry
+++ b/Dockerfile.registry
@@ -57,6 +57,9 @@ COPY CONTRIBUTING.md ./
 # Install the current project
 RUN poetry install --only main --no-interaction --no-ansi
 
+# Build CSS assets at image build time (not at runtime, to avoid OOM kills)
+RUN npm run build:css
+
 # Create non-root user for security
 RUN groupadd -r checktick && useradd -r -g checktick checktick && \
     mkdir -p /app/media /app/staticfiles && \
@@ -70,5 +73,5 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/api/health || exit 1
 
-# Default command - build CSS at runtime to ensure fresh styles
-CMD ["sh", "-c", "npm run build:css && python manage.py migrate --noinput && python manage.py sync_branding && python manage.py sync_nhs_dd_datasets && python manage.py collectstatic --noinput --clear && CSS_HASH=$(md5sum /app/staticfiles/build/styles.css | cut -d' ' -f1) && cp /app/staticfiles/build/styles.css /app/staticfiles/build/styles.$CSS_HASH.css && echo $CSS_HASH > /tmp/css_hash.txt && gunicorn checktick_app.wsgi:application --bind 0.0.0.0:8000 --workers 4"]
+# Default command
+CMD ["sh", "-c", "python manage.py migrate --noinput && python manage.py sync_branding && python manage.py sync_nhs_dd_datasets && python manage.py collectstatic --noinput --clear && CSS_HASH=$(md5sum /app/staticfiles/build/styles.css | cut -d' ' -f1) && cp /app/staticfiles/build/styles.css /app/staticfiles/build/styles.$CSS_HASH.css && echo $CSS_HASH > /tmp/css_hash.txt && gunicorn checktick_app.wsgi:application --bind 0.0.0.0:8000 --workers 4"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "checktick"
-version = "0.4.4"
+version = "0.4.5"
 description = "Secure, server-rendered survey platform for medical audit and research"
 authors = ["CheckTick Maintainers <simon@eatyourpeas.co.uk>"]
 readme = "README.md"


### PR DESCRIPTION
## Problem

In `Dockerfile.registry`, `npm run build:css` (tailwindcss) was being run at **container startup** inside the `CMD`. This triggered a memory-intensive build every time the container started, causing repeated OOM kills (exit code 137) and a crash loop in production.

## Fix

Moved `npm run build:css` to a `RUN` step during the Docker image build (after all source files are copied). CSS is now baked into the image, so container startup no longer requires the memory spike.

This matches the pattern already correctly used in the main `Dockerfile`.

## Changes

- `Dockerfile.registry` — CSS built at image build time via `RUN npm run build:css`, removed from `CMD`
- `pyproject.toml` — patch bump `0.4.4` → `0.4.5`