### PR TITLE
a further bump in the sct package published by eatyourpeas to overcome parsing failure to snomed monolith on amd64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN pip install --no-cache-dir --upgrade pip>=26.0
 RUN pip install --no-cache-dir poetry==${POETRY_VERSION}
 
 # Install sct binary (SNOMED CT toolchain) — pre-built release, no Rust needed
-ARG SCT_VERSION=v0.3.11-ctfix2
+ARG SCT_VERSION=v0.3.11-ctfix3
 ARG SCT_REPO=eatyourpeas/sct
 RUN set -eux; \
     ARCH=$(uname -m); \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends build-essential
 RUN pip install --no-cache-dir poetry==${POETRY_VERSION}
 
 # Install sct binary (SNOMED CT toolchain) — pre-built release, no Rust needed
-ARG SCT_VERSION=v0.3.11-ctfix2
+ARG SCT_VERSION=v0.3.11-ctfix3
 ARG SCT_REPO=eatyourpeas/sct
 RUN set -eux; \
     ARCH=$(uname -m); \

--- a/Dockerfile.registry
+++ b/Dockerfile.registry
@@ -21,7 +21,7 @@ RUN pip install --no-cache-dir poetry==${POETRY_VERSION}
 # Install sct binary (SNOMED CT toolchain) — pre-built release, no Rust needed
 # TARGETARCH must be declared to expose the BuildKit automatic platform ARG to RUN steps
 ARG TARGETARCH
-ARG SCT_VERSION=v0.3.11-ctfix2
+ARG SCT_VERSION=v0.3.11-ctfix3
 ARG SCT_REPO=eatyourpeas/sct
 RUN set -eux; \
     case "$TARGETARCH" in \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "checktick"
-version = "0.4.8"
+version = "0.4.9"
 description = "Secure, server-rendered survey platform for medical audit and research"
 authors = ["CheckTick Maintainers <simon@eatyourpeas.co.uk>"]
 readme = "README.md"


### PR DESCRIPTION
SCT continually fails to parse into ndjson although the zips download in production (linux/amd64).
SCT now fixed and works in a dockerised linux environment so this version has been released from eatyourpeas. once/if merged upstream can revert to that