### PR TITLE
Add SNOMED prune option and switch self-hosted guidance to manual updates

### DIFF
--- a/checktick_app/surveys/management/commands/update_snomed_db.py
+++ b/checktick_app/surveys/management/commands/update_snomed_db.py
@@ -14,6 +14,7 @@ refresh member counts and the release date stored in Postgres.
 Usage:
     python manage.py update_snomed_db
     python manage.py update_snomed_db --force   # skip check, always download
+    python manage.py update_snomed_db --force --prune   # clean stale artefacts first
     python manage.py update_snomed_db --edition uk_drug   # alternative edition
     python manage.py update_snomed_db --dry-run
 
@@ -25,6 +26,7 @@ Requirements:
 
 import os
 from pathlib import Path
+import shutil
 import subprocess
 import sys
 
@@ -40,6 +42,28 @@ SCT_EXIT_ERROR = 1
 
 def _get_setting(name: str, default: str = "") -> str:
     return getattr(settings, name, None) or os.environ.get(name, default)
+
+
+def _prune_snomed_artifacts(data_dir: Path, snomed_db_path: Path):
+    """Remove stale SNOMED build artefacts to reduce peak disk usage."""
+    removed = []
+
+    tmp_dir = data_dir / "tmp"
+    if tmp_dir.exists():
+        shutil.rmtree(tmp_dir)
+        removed.append(tmp_dir.name + "/")
+
+    for zip_path in sorted(data_dir.glob("*.zip")):
+        zip_path.unlink()
+        removed.append(zip_path.name)
+
+    for db_path in sorted(data_dir.glob("uk_sct2*.db")):
+        if db_path.resolve() == snomed_db_path.resolve():
+            continue
+        db_path.unlink()
+        removed.append(db_path.name)
+
+    return removed
 
 
 class Command(BaseCommand):
@@ -65,11 +89,20 @@ class Command(BaseCommand):
             action="store_true",
             help="Show what would happen without running sct commands or saving",
         )
+        parser.add_argument(
+            "--prune",
+            action="store_true",
+            help=(
+                "Delete stale tmp/zip/versioned db artefacts in SNOMED data dir "
+                "before checking/downloading"
+            ),
+        )
 
     def handle(self, *args, **options):
         force = options["force"]
         edition = options["edition"]
         dry_run = options["dry_run"]
+        prune = options["prune"]
 
         if dry_run:
             self.stdout.write(
@@ -96,7 +129,8 @@ class Command(BaseCommand):
             )
             sys.exit(1)
 
-        data_dir = str(Path(snomed_db_path).parent)
+        snomed_db = Path(snomed_db_path)
+        data_dir = snomed_db.parent
 
         # Verify sct binary is available (skipped in dry-run)
         if not dry_run:
@@ -117,6 +151,26 @@ class Command(BaseCommand):
                 sys.exit(1)
         else:
             self.stdout.write("🔧 sct binary: (not checked in dry-run)")
+
+        if prune:
+            if dry_run:
+                self.stdout.write(
+                    "   [DRY RUN] would prune stale tmp/, *.zip and uk_sct2*.db artefacts"
+                )
+            else:
+                self.stdout.write("🧹 Pruning stale SNOMED artefacts before update...")
+                try:
+                    removed = _prune_snomed_artifacts(data_dir, snomed_db)
+                except Exception as exc:
+                    self.stdout.write(
+                        self.style.ERROR(f"❌ Failed to prune SNOMED artefacts: {exc}")
+                    )
+                    sys.exit(1)
+
+                if removed:
+                    self.stdout.write(f"   Removed {len(removed)} artefact(s).")
+                else:
+                    self.stdout.write("   Nothing to prune.")
 
         # ── Step 1: check for update (unless --force) ─────────────────────
         needs_update = force
@@ -198,7 +252,7 @@ class Command(BaseCommand):
             # Redirect TMPDIR to the mounted volume so that sct's intermediate
             # files (ndjson extraction, SQLite build) do not fill the container's
             # ephemeral storage and trigger an eviction/OOM kill.
-            tmp_dir = str(Path(data_dir) / "tmp")
+            tmp_dir = str(data_dir / "tmp")
             Path(tmp_dir).mkdir(parents=True, exist_ok=True)
 
             download_result = subprocess.run(
@@ -209,9 +263,9 @@ class Command(BaseCommand):
                     "--edition",
                     edition,
                     "--output-dir",
-                    data_dir,
+                    str(data_dir),
                     "--data-dir",
-                    data_dir,
+                    str(data_dir),
                     "--pipeline",
                 ],
                 text=True,
@@ -235,13 +289,12 @@ class Command(BaseCommand):
 
             # sct writes a release-versioned filename (e.g. uk_sct2mo_42.1.0_….db).
             # Rename it to the canonical path that SNOMED_DB_PATH points to.
-            versioned_dbs = sorted(Path(data_dir).glob("uk_sct2mo_*.db"))
+            versioned_dbs = sorted(data_dir.glob("uk_sct2mo_*.db"))
             if versioned_dbs:
                 versioned_db = versioned_dbs[-1]
-                target = Path(snomed_db_path)
-                versioned_db.rename(target)
-                self.stdout.write(f"   Renamed {versioned_db.name} → {target.name}")
-            elif not Path(snomed_db_path).exists():
+                versioned_db.rename(snomed_db)
+                self.stdout.write(f"   Renamed {versioned_db.name} → {snomed_db.name}")
+            elif not snomed_db.exists():
                 self.stdout.write(
                     self.style.ERROR(
                         f"❌ No .db file found in {data_dir} after build — rename failed."

--- a/docs/self-hosting-scheduled-tasks.md
+++ b/docs/self-hosting-scheduled-tasks.md
@@ -8,7 +8,7 @@ CheckTick requires scheduled tasks for data governance operations, housekeeping,
 
 ## Overview
 
-CheckTick uses eight scheduled tasks:
+CheckTick uses eight scheduled tasks, plus one optional manual SNOMED CT maintenance task:
 
 ### 1. Data Governance (Required for GDPR)
 
@@ -76,25 +76,25 @@ python manage.py sync_nhs_dd_datasets --force
 python manage.py sync_nhs_dd_datasets --dataset smoking_status_code
 ```
 
-### 5. SNOMED CT Update (Optional — requires TRUD API key)
+### 5. SNOMED CT Update (Optional, Manual — requires TRUD API key)
 
-The `update_snomed_db` management command runs weekly to:
+The `update_snomed_db` management command is intended to run infrequently from inside the container shell (for example monthly, or when you want to refresh terminology):
 
 1. **Check for a new release** — calls `sct trud check`, which hits the TRUD API and exits immediately (exit 0) if there is nothing new. The 1.8 GB download only starts if a new release is detected (exit 2).
 2. **Download and rebuild snomed.db** — runs `sct trud download --pipeline`, producing a fresh SQLite database on the `snomed-data` volume.
 3. **Refresh dataset descriptors** — automatically re-runs `seed_snomed_datasets --force` to update member counts and the release date in Postgres.
 
-**Optional**: If `TRUD_API_KEY` is not set the command exits cleanly, so it is safe to schedule unconditionally even in non-SNOMED deployments.
+**Optional**: If `TRUD_API_KEY` is not set the command exits cleanly.
 
-**Schedule**: Weekly is sufficient — SNOMED CT releases approximately monthly. The early-exit check costs almost nothing when there is no update, so running weekly adds negligible overhead.
+**Frequency**: Infrequent/manual is recommended for self-hosted deployments.
 
-> **TRUD maintenance windows**: TRUD is offline weekdays 18:00–08:00 UK time (and midnight–06:00). Schedule the job during UK business hours to avoid false failures (e.g. Wednesday 10:00 UTC).
+> **TRUD maintenance windows**: TRUD is offline weekdays 18:00–08:00 UK time (and midnight–06:00). Run manual updates during UK business hours to avoid false failures.
 
 **Initial Setup**: Seed the SNOMED CT dataset descriptors once after building snomed.db:
 
 ```bash
 # Build snomed.db from TRUD (takes several minutes — ~1.8 GB download)
-python manage.py update_snomed_db --force
+python manage.py update_snomed_db --force --prune
 
 # Or if snomed.db already exists on the volume:
 python manage.py seed_snomed_datasets
@@ -107,7 +107,7 @@ python manage.py seed_snomed_datasets
 python manage.py update_snomed_db --dry-run
 
 # Force a full download regardless of current state
-python manage.py update_snomed_db --force
+python manage.py update_snomed_db --force --prune
 
 # Use an alternative edition (default: uk_monolith)
 python manage.py update_snomed_db --edition uk_drug
@@ -257,20 +257,19 @@ Northflank provides native cron job support, making this the simplest option.
    - **Schedule**: `0 5 * * 0` (runs at 5 AM UTC every Sunday - weekly)
    - **Command**: `python manage.py sync_nhs_dd_datasets`
 
-#### 5. Create SNOMED CT Update Cron Job (Optional)
+#### 5. SNOMED CT Manual Maintenance (No Cron Job)
 
-> Skip this step if you are not using SNOMED CT (no `TRUD_API_KEY`).
+If you use SNOMED CT, run updates manually from the web service/container shell during a maintenance window:
 
-1. Click **"Add Service"** → **"Cron Job"** again
-2. Configure the job:
-   - **Name**: `checktick-snomed-update`
-   - **Docker Image**: Use the same image as your web service (must include the `sct` binary)
-   - **Schedule**: `0 10 * * 3` (runs at 10 AM UTC every Wednesday — inside TRUD business hours)
-   - **Command**: `python manage.py update_snomed_db`
-3. Mount the **`snomed-data`** volume to `/app/data` in this cron job (same as the web service)
-4. Add `TRUD_API_KEY` and `SNOMED_DB_PATH` to the job's environment variables
+```bash
+# Check for a new release (no download)
+python manage.py update_snomed_db --dry-run
 
-> **Note:** The job exits immediately (exit 0) if SNOMED CT is already up to date, so running it weekly adds negligible overhead.
+# Rebuild safely on persistent storage with cleanup first
+python manage.py update_snomed_db --force --prune
+```
+
+Recommended cadence is monthly (or on demand), since releases are infrequent.
 
 #### 6. Create Global Templates Sync Cron Job
 
@@ -307,7 +306,7 @@ All cron jobs need the same environment variables as your web service:
 - `DEFAULT_FROM_EMAIL` (for data governance)
 - `SITE_URL` (for email links in data governance)
 - `EXTERNAL_DATASET_API_URL`, `EXTERNAL_DATASET_API_KEY` (for dataset sync - optional, defaults to RCPCH API)
-- `TRUD_API_KEY`, `SNOMED_DB_PATH` (for SNOMED CT update job — optional)
+- `TRUD_API_KEY`, `SNOMED_DB_PATH` (optional — required only if you use SNOMED CT)
 
 #### 9. Deploy and Test
 
@@ -345,12 +344,11 @@ The `&&` ensures the ping only fires if the management command exits successfull
 **Example commands with heartbeat ping:**
 
 | Job | Command |
-|---|---|
+| --- | --- |
 | census-data-governance | `python manage.py process_data_governance && curl -fsS --retry 3 https://hc-ping.com/<uuid> > /dev/null` |
 | checktick-progress-cleanup | `python manage.py cleanup_survey_progress && curl -fsS --retry 3 https://hc-ping.com/<uuid> > /dev/null` |
 | checktick-data-sync | `python manage.py sync_external_datasets && curl -fsS --retry 3 https://hc-ping.com/<uuid> > /dev/null` |
 | checktick-nhsdd-sync | `python manage.py sync_nhs_dd_datasets && curl -fsS --retry 3 https://hc-ping.com/<uuid> > /dev/null` |
-| checktick-snomed-update | `python manage.py update_snomed_db && curl -fsS --retry 3 https://hc-ping.com/<uuid> > /dev/null` |
 | checktick-templates-sync | `python manage.py sync_global_question_group_templates && curl -fsS --retry 3 https://hc-ping.com/<uuid> > /dev/null` |
 
 > **App and Vault uptime:** Use an external uptime monitor (e.g. StatusCake, UptimeRobot) pointing at `https://your-domain/healthz`. This endpoint returns `503` if Vault is sealed, the database is unreachable, or SNOMED CT is misconfigured — giving you a single URL to monitor for all critical service health.
@@ -438,24 +436,6 @@ docker compose exec -T web python manage.py sync_global_question_group_templates
 exit $?
 ```
 
-Create `/usr/local/bin/checktick-snomed-update.sh` (optional — only if using SNOMED CT):
-
-```bash
-#!/bin/bash
-# CheckTick SNOMED CT Update Cron Job
-# Runs weekly on Wednesday at 10 AM UTC (inside TRUD business hours)
-# Exits immediately (exit 0) if SNOMED CT is already up to date.
-
-# Set working directory
-cd /path/to/your/checktick-app
-
-# Run the update command
-docker compose exec -T web python manage.py update_snomed_db >> /var/log/checktick/snomed-update.log 2>&1
-
-# Exit with the command's exit code
-exit $?
-```
-
 Make them executable:
 
 ```bash
@@ -463,7 +443,6 @@ chmod +x /usr/local/bin/checktick-data-governance.sh
 chmod +x /usr/local/bin/checktick-progress-cleanup.sh
 chmod +x /usr/local/bin/checktick-dataset-sync.sh
 chmod +x /usr/local/bin/checktick-templates-sync.sh
-chmod +x /usr/local/bin/checktick-snomed-update.sh  # if using SNOMED CT
 ```
 
 #### 2. Add to System Crontab
@@ -486,9 +465,6 @@ Add these lines:
 
 # CheckTick Global Templates Sync - Daily at 6 AM UTC
 0 6 * * * /usr/local/bin/checktick-templates-sync.sh
-
-# CheckTick SNOMED CT Update - Weekly Wednesday 10 AM UTC (optional)
-0 10 * * 3 /usr/local/bin/checktick-snomed-update.sh
 ```
 
 #### 3. Create Log Directory
@@ -525,13 +501,20 @@ cd /path/to/your/checktick-app
 docker compose exec web python manage.py sync_external_datasets
 ```
 
+If you use SNOMED CT, run updates manually from inside the running web container (for example monthly):
+
+```bash
+docker compose exec web python manage.py update_snomed_db --dry-run
+docker compose exec web python manage.py update_snomed_db --force --prune
+```
+
 ---
 
 ### Kubernetes
 
 If you're running CheckTick in Kubernetes, use a CronJob resource.
 
-#### Create a CronJob manifest:
+#### Create a CronJob manifest
 
 ```yaml
 apiVersion: batch/v1

--- a/docs/snomed-integration.md
+++ b/docs/snomed-integration.md
@@ -169,17 +169,16 @@ python manage.py seed_snomed_datasets --dry-run
 
 Checks TRUD for a newer SNOMED CT UK Monolith release. If one is found, downloads and rebuilds `snomed.db` via `sct trud download --pipeline`, then updates `snomed_release_date` on all SNOMED descriptor records.
 
+Use `--prune` when running updates on constrained volumes. It removes stale `tmp/`, downloaded zip files, and old versioned `uk_sct2*.db` artefacts before the update check/build starts.
+
 ```bash
 python manage.py update_snomed_db
 python manage.py update_snomed_db --force    # re-download even if current
 python manage.py update_snomed_db --dry-run  # check for new release only
+python manage.py update_snomed_db --force --prune  # free space before rebuild
 ```
 
-SNOMED CT UK is published **twice a year** (typically April and October). A weekly cron check is the recommended schedule — the command is a no-op when no new release is available.
-
-```cron
-0 6 * * 1  python manage.py update_snomed_db
-```
+SNOMED CT UK is published infrequently. For self-hosted deployments, prefer a **manual in-container update** during a planned maintenance window (for example monthly or only when you want to refresh terminology), rather than a scheduled cron job.
 
 See [Scheduled Tasks](self-hosting-scheduled-tasks.md) for Northflank setup.
 
@@ -231,9 +230,9 @@ docker compose exec web python manage.py seed_snomed_datasets
 | `sct ndjson`     | NDJSON intermediate    | ~1 GB+           |
 | `sct sqlite`     | Final `snomed.db`      | ~500 MB–1 GB     |
 
-Peak disk usage during a build is approximately **3.5 GB**. All intermediate and output files must be written to the mounted persistent volume (not container ephemeral storage). A **10 GB volume** is the recommended minimum.
+Peak disk usage during a build can exceed **6 GB** when temporary artefacts and the existing `snomed.db` overlap. All intermediate and output files must be written to the mounted persistent volume (not container ephemeral storage). A **10 GB volume** is the practical minimum; **20 GB** is recommended for safer headroom.
 
-The `snomed.db` volume must be shared between the web service (reads) and the `checktick-snomed-update` cron job (writes). The cron job should run on a higher compute spec (e.g. `nf-compute-200`) as the build process is CPU- and I/O-intensive. The web service just reads via lightweight SQLite queries and requires no additional resources beyond its standard spec.
+Run updates from inside the existing web/container shell, and use `--prune` before forced rebuilds to reduce burst usage.
 
 The `vault-data` volume is dedicated to HashiCorp Vault's Raft storage and must not be shared.
 
@@ -304,7 +303,7 @@ The architecture is designed to extend. If `sct` gains support for additional te
 
 - [Dataset Loading Architecture](dataset-loading-architecture.md) — full data flow for all dataset types
 - [Datasets and Dropdowns](datasets-and-dropdowns.md) — user-facing guide
-- [Self-hosting Scheduled Tasks](self-hosting-scheduled-tasks.md) — cron job setup for `update_snomed_db`
+- [Self-hosting Scheduled Tasks](self-hosting-scheduled-tasks.md) — manual SNOMED maintenance guidance
 - [`sct` project](https://github.com/pacharanero/sct) — the Rust binary that generates `snomed.db`
 - [NHS TRUD](https://isd.digital.nhs.uk/trud) — source of SNOMED CT releases
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "checktick"
-version = "0.4.9"
+version = "0.4.10"
 description = "Secure, server-rendered survey platform for medical audit and research"
 authors = ["CheckTick Maintainers <simon@eatyourpeas.co.uk>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
- add a new `--prune` flag to `update_snomed_db` to remove stale SNOMED temp/download/versioned DB artifacts before running checks/downloads
- keep existing `--force` behavior and wire prune handling into dry-run and normal execution paths
- update SNOMED docs to recommend infrequent manual in-container updates (instead of scheduled SNOMED cron jobs)
- update scheduled task documentation to remove SNOMED cron setup and provide manual maintenance commands
- include the existing `pyproject.toml` version update from this branch

## Why
- reduce peak disk pressure during SNOMED rebuilds on persistent volumes
- align self-hosted operational guidance with safer manual update cadence for large SNOMED artifacts

## Validation
- `s/lint` passes locally