### PR TITLE
Fix platform admin billing and validation regressions

### DIFF
--- a/checktick_app/core/billing.py
+++ b/checktick_app/core/billing.py
@@ -18,6 +18,8 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 import requests
 
+from checktick_app.core.models import PricingOverride
+
 logger = logging.getLogger(__name__)
 User = get_user_model()
 
@@ -586,7 +588,7 @@ def create_subscription_for_user(user, tier: str, mandate_id: str) -> str:
         PaymentAPIError: If subscription creation fails
         ValueError: If tier is not configured
     """
-    tier_config = settings.SUBSCRIPTION_TIERS.get(tier)
+    tier_config = PricingOverride.get_effective_tiers().get(tier)
     if not tier_config:
         raise ValueError(f"Unknown subscription tier: {tier}")
 

--- a/checktick_app/core/views_platform_admin.py
+++ b/checktick_app/core/views_platform_admin.py
@@ -1,6 +1,6 @@
 """Platform admin views for superuser management of organizations."""
 
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 import logging
 
 from django.contrib import messages
@@ -18,6 +18,53 @@ from checktick_app.surveys.models import Organization, OrganizationMembership, S
 
 logger = logging.getLogger(__name__)
 User = get_user_model()
+
+
+def _render_organization_form(
+    request: HttpRequest,
+    *,
+    editing: bool = False,
+    org: Organization | None = None,
+    form_data=None,
+) -> HttpResponse:
+    context = {
+        "billing_choices": Organization.BillingType.choices,
+    }
+    if editing:
+        context.update(
+            {
+                "org": org,
+                "status_choices": Organization.SubscriptionStatus.choices,
+                "editing": True,
+            }
+        )
+    if form_data is not None:
+        context["form_data"] = form_data
+    return render(request, "core/platform_admin/organization_form.html", context)
+
+
+def _parse_decimal_field(value: str, label: str, errors: list[str]) -> Decimal | None:
+    if not value:
+        return None
+    try:
+        return Decimal(value)
+    except InvalidOperation:
+        errors.append(f"{label} must be a valid number.")
+        return None
+
+
+def _parse_max_seats(value: str, errors: list[str]) -> int | None:
+    if not value:
+        return None
+    try:
+        parsed = int(value)
+    except ValueError:
+        errors.append("Maximum seats must be a whole number.")
+        return None
+    if parsed < 1:
+        errors.append("Maximum seats must be at least 1.")
+        return None
+    return parsed
 
 
 def superuser_required(view_func):
@@ -154,27 +201,38 @@ def organization_create(request: HttpRequest) -> HttpResponse:
 
         # Validation
         errors = []
+        valid_billing_types = {
+            choice for choice, _label in Organization.BillingType.choices
+        }
+
         if not name:
             errors.append("Organization name is required.")
         if not owner_email:
             errors.append("Owner email is required.")
+        if billing_type not in valid_billing_types:
+            errors.append("Invalid billing type selected.")
 
         if billing_type == Organization.BillingType.PER_SEAT and not price_per_seat:
             errors.append("Price per seat is required for per-seat billing.")
         if billing_type == Organization.BillingType.FLAT_RATE and not flat_rate_price:
             errors.append("Flat rate price is required for flat-rate billing.")
 
+        parsed_price_per_seat = _parse_decimal_field(
+            price_per_seat,
+            "Price per seat",
+            errors,
+        )
+        parsed_flat_rate_price = _parse_decimal_field(
+            flat_rate_price,
+            "Flat rate price",
+            errors,
+        )
+        parsed_max_seats = _parse_max_seats(max_seats, errors)
+
         if errors:
             for error in errors:
                 messages.error(request, error)
-            return render(
-                request,
-                "core/platform_admin/organization_form.html",
-                {
-                    "billing_choices": Organization.BillingType.choices,
-                    "form_data": request.POST,
-                },
-            )
+            return _render_organization_form(request, form_data=request.POST)
 
         # Find or create owner
         owner = User.objects.filter(email__iexact=owner_email).first()
@@ -196,9 +254,9 @@ def organization_create(request: HttpRequest) -> HttpResponse:
             name=name,
             owner=owner,
             billing_type=billing_type,
-            price_per_seat=Decimal(price_per_seat) if price_per_seat else None,
-            flat_rate_price=Decimal(flat_rate_price) if flat_rate_price else None,
-            max_seats=int(max_seats) if max_seats else None,
+            price_per_seat=parsed_price_per_seat,
+            flat_rate_price=parsed_flat_rate_price,
+            max_seats=parsed_max_seats,
             billing_contact_email=billing_contact_email or owner_email,
             billing_notes=billing_notes,
             created_by=request.user,
@@ -226,13 +284,7 @@ def organization_create(request: HttpRequest) -> HttpResponse:
         return redirect("core:platform_admin_org_detail", org_id=org.id)
 
     # GET - show form
-    return render(
-        request,
-        "core/platform_admin/organization_form.html",
-        {
-            "billing_choices": Organization.BillingType.choices,
-        },
-    )
+    return _render_organization_form(request)
 
 
 @superuser_required
@@ -287,27 +339,64 @@ def organization_edit(request: HttpRequest, org_id: int) -> HttpResponse:
     org = get_object_or_404(Organization, id=org_id)
 
     if request.method == "POST":
-        # Update fields
-        org.name = request.POST.get("name", org.name).strip()
-        org.billing_type = request.POST.get("billing_type", org.billing_type)
-
+        name = request.POST.get("name", org.name).strip()
+        billing_type = request.POST.get("billing_type", org.billing_type)
         price_per_seat = request.POST.get("price_per_seat", "").strip()
-        org.price_per_seat = Decimal(price_per_seat) if price_per_seat else None
-
         flat_rate_price = request.POST.get("flat_rate_price", "").strip()
-        org.flat_rate_price = Decimal(flat_rate_price) if flat_rate_price else None
-
         max_seats = request.POST.get("max_seats", "").strip()
-        org.max_seats = int(max_seats) if max_seats else None
-
-        org.billing_contact_email = request.POST.get(
-            "billing_contact_email", ""
-        ).strip()
-        org.billing_notes = request.POST.get("billing_notes", "").strip()
-        org.subscription_status = request.POST.get(
+        billing_contact_email = request.POST.get("billing_contact_email", "").strip()
+        billing_notes = request.POST.get("billing_notes", "").strip()
+        subscription_status = request.POST.get(
             "subscription_status", org.subscription_status
         )
-        org.is_active = request.POST.get("is_active") == "on"
+        is_active = request.POST.get("is_active") == "on"
+
+        errors = []
+        valid_billing_types = {
+            choice for choice, _label in Organization.BillingType.choices
+        }
+        valid_subscription_statuses = {
+            choice for choice, _label in Organization.SubscriptionStatus.choices
+        }
+
+        if not name:
+            errors.append("Organization name is required.")
+        if billing_type not in valid_billing_types:
+            errors.append("Invalid billing type selected.")
+        if subscription_status not in valid_subscription_statuses:
+            errors.append("Invalid subscription status selected.")
+        if billing_type == Organization.BillingType.PER_SEAT and not price_per_seat:
+            errors.append("Price per seat is required for per-seat billing.")
+        if billing_type == Organization.BillingType.FLAT_RATE and not flat_rate_price:
+            errors.append("Flat rate price is required for flat-rate billing.")
+
+        parsed_price_per_seat = _parse_decimal_field(
+            price_per_seat,
+            "Price per seat",
+            errors,
+        )
+        parsed_flat_rate_price = _parse_decimal_field(
+            flat_rate_price,
+            "Flat rate price",
+            errors,
+        )
+        parsed_max_seats = _parse_max_seats(max_seats, errors)
+
+        if errors:
+            for error in errors:
+                messages.error(request, error)
+            return _render_organization_form(request, editing=True, org=org)
+
+        # Update fields
+        org.name = name
+        org.billing_type = billing_type
+        org.price_per_seat = parsed_price_per_seat
+        org.flat_rate_price = parsed_flat_rate_price
+        org.max_seats = parsed_max_seats
+        org.billing_contact_email = billing_contact_email
+        org.billing_notes = billing_notes
+        org.subscription_status = subscription_status
+        org.is_active = is_active
 
         org.save()
 
@@ -315,16 +404,7 @@ def organization_edit(request: HttpRequest, org_id: int) -> HttpResponse:
         messages.success(request, f"Organization '{org.name}' updated successfully.")
         return redirect("core:platform_admin_org_detail", org_id=org.id)
 
-    return render(
-        request,
-        "core/platform_admin/organization_form.html",
-        {
-            "org": org,
-            "billing_choices": Organization.BillingType.choices,
-            "status_choices": Organization.SubscriptionStatus.choices,
-            "editing": True,
-        },
-    )
+    return _render_organization_form(request, editing=True, org=org)
 
 
 @superuser_required

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "checktick"
-version = "0.4.10"
+version = "0.4.11"
 description = "Secure, server-rendered survey platform for medical audit and research"
 authors = ["CheckTick Maintainers <simon@eatyourpeas.co.uk>"]
 readme = "README.md"

--- a/tests/test_platform_admin_regressions.py
+++ b/tests/test_platform_admin_regressions.py
@@ -1,0 +1,148 @@
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+import pytest
+
+from checktick_app.core.billing import create_subscription_for_user
+from checktick_app.core.models import PricingOverride
+from checktick_app.surveys.models import Organization
+
+User = get_user_model()
+
+TEST_PASSWORD = "x"
+
+
+@pytest.fixture
+def superuser(db):
+    return User.objects.create_superuser(
+        username="superadmin_regression",
+        email="superadmin-regression@test.com",
+        password=TEST_PASSWORD,
+    )
+
+
+@pytest.fixture
+def regular_user(db):
+    return User.objects.create_user(
+        username="regular_regression",
+        email="regular-regression@test.com",
+        password=TEST_PASSWORD,
+    )
+
+
+@pytest.fixture
+def test_organization(db, superuser):
+    owner = User.objects.create_user(
+        username="orgowner_regression",
+        email="orgowner-regression@test.com",
+        password=TEST_PASSWORD,
+    )
+    return Organization.objects.create(
+        name="Regression Test Organization",
+        owner=owner,
+        billing_type=Organization.BillingType.PER_SEAT,
+        price_per_seat="10.00",
+        subscription_status=Organization.SubscriptionStatus.PENDING,
+        created_by=superuser,
+    )
+
+
+@pytest.mark.django_db
+def test_checkout_uses_active_pricing_override(monkeypatch):
+    user = User.objects.create_user(
+        username="billing_regression",
+        email="billing-regression@test.com",
+        password=TEST_PASSWORD,
+    )
+    overridden_amount = settings.SUBSCRIPTION_TIERS["pro"]["amount"] + 111
+    overridden_amount_ex_vat = settings.SUBSCRIPTION_TIERS["pro"]["amount_ex_vat"] + 93
+    PricingOverride.objects.create(
+        tier="pro",
+        amount=overridden_amount,
+        amount_ex_vat=overridden_amount_ex_vat,
+        is_active=True,
+    )
+
+    captured = {}
+
+    def fake_create_subscription(**kwargs):
+        captured.update(kwargs)
+        return {"id": "SUB_123"}
+
+    monkeypatch.setattr(
+        "checktick_app.core.billing.payment_client.create_subscription",
+        fake_create_subscription,
+    )
+
+    subscription_id = create_subscription_for_user(
+        user=user,
+        tier="pro",
+        mandate_id="MD123",
+    )
+
+    assert subscription_id == "SUB_123"
+    assert captured["amount"] == overridden_amount
+
+
+@pytest.mark.django_db
+def test_organization_create_invalid_numeric_input_returns_form(client, superuser):
+    client.force_login(superuser)
+
+    response = client.post(
+        reverse("core:platform_admin_org_create"),
+        {
+            "name": "Broken Numeric Org",
+            "owner_email": "broken-numeric@example.com",
+            "billing_type": Organization.BillingType.PER_SEAT,
+            "price_per_seat": "not-a-number",
+        },
+    )
+
+    assert response.status_code == 200
+    assert not Organization.objects.filter(name="Broken Numeric Org").exists()
+
+
+@pytest.mark.django_db
+def test_organization_create_rejects_invalid_billing_type(client, superuser):
+    client.force_login(superuser)
+
+    response = client.post(
+        reverse("core:platform_admin_org_create"),
+        {
+            "name": "Invalid Billing Type Org",
+            "owner_email": "invalid-billing-type@example.com",
+            "billing_type": "bogus-tier",
+            "price_per_seat": "12.50",
+        },
+    )
+
+    assert response.status_code == 200
+    assert not Organization.objects.filter(name="Invalid Billing Type Org").exists()
+
+
+@pytest.mark.django_db
+def test_organization_edit_rejects_invalid_subscription_status(
+    client, superuser, test_organization
+):
+    client.force_login(superuser)
+
+    response = client.post(
+        reverse(
+            "core:platform_admin_org_edit", kwargs={"org_id": test_organization.id}
+        ),
+        {
+            "name": test_organization.name,
+            "billing_type": Organization.BillingType.PER_SEAT,
+            "price_per_seat": "10.00",
+            "subscription_status": "definitely-not-valid",
+            "billing_contact_email": "billing@example.com",
+            "is_active": "on",
+        },
+    )
+
+    test_organization.refresh_from_db()
+
+    assert response.status_code == 200
+    assert (
+        test_organization.subscription_status == Organization.SubscriptionStatus.PENDING
+    )


### PR DESCRIPTION
## Summary
Fix three platform admin regressions and bump the package version so merging triggers a new deploy.

## Changes
- honor active `PricingOverride` values when creating new subscriptions so checkout pricing matches the platform admin pricing page for new subscriptions
- add server-side validation for platform admin organization create and edit flows to reject invalid billing types, invalid subscription statuses, malformed decimal inputs, and non-numeric seat counts before saving
- add focused regression coverage for override-aware checkout pricing and organization create/edit validation behavior
- bump `pyproject.toml` from `0.4.10` to `0.4.11`

## Validation
- `s/test --no-a11y tests/test_platform_admin_regressions.py`
- `s/lint`