### PR TITLE
Fix survey group ordering mismatch between Survey Map, Preview, and Live

### DIFF
--- a/checktick_app/surveys/tests/test_runtime_ordering_consistency.py
+++ b/checktick_app/surveys/tests/test_runtime_ordering_consistency.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import json
 
-import pytest
 from django.contrib.auth import get_user_model
 from django.urls import reverse
+import pytest
 
 from checktick_app.surveys.models import (
     Organization,

--- a/checktick_app/surveys/tests/test_runtime_ordering_consistency.py
+++ b/checktick_app/surveys/tests/test_runtime_ordering_consistency.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from checktick_app.surveys.models import (
+    Organization,
+    QuestionGroup,
+    Survey,
+    SurveyQuestion,
+)
+
+User = get_user_model()
+
+
+def _group_sequence(questions: list[SurveyQuestion]) -> list[str]:
+    """Return ordered unique group names from a question list."""
+    sequence: list[str] = []
+    for q in questions:
+        name = q.group.name if q.group else ""
+        if name and (not sequence or sequence[-1] != name):
+            sequence.append(name)
+    return sequence
+
+
+@pytest.mark.django_db
+def test_survey_map_preview_take_share_same_question_order(client):
+    owner = User.objects.create_user(username="owner-order", password="x")
+    org = Organization.objects.create(name="Org", owner=owner)
+
+    survey = Survey.objects.create(
+        owner=owner,
+        organization=org,
+        name="Order Contract",
+        slug="order-contract",
+        status=Survey.Status.PUBLISHED,
+        visibility=Survey.Visibility.PUBLIC,
+    )
+
+    group_a = QuestionGroup.objects.create(name="Group A", owner=owner)
+    group_b = QuestionGroup.objects.create(name="Group B", owner=owner)
+    survey.question_groups.add(group_a, group_b)
+
+    # Intentionally make global question.order conflict with desired group order.
+    # Desired order (via /groups map state): A then B.
+    style = survey.style or {}
+    style["group_order"] = [group_a.id, group_b.id]
+    survey.style = style
+    survey.save(update_fields=["style"])
+
+    q_b = SurveyQuestion.objects.create(
+        survey=survey,
+        group=group_b,
+        text="B question",
+        type=SurveyQuestion.Types.TEXT,
+        order=0,
+    )
+    q_a = SurveyQuestion.objects.create(
+        survey=survey,
+        group=group_a,
+        text="A question",
+        type=SurveyQuestion.Types.TEXT,
+        order=1,
+    )
+
+    client.force_login(owner)
+
+    # Survey Map source of truth
+    map_resp = client.get(
+        reverse("surveys:branching_data_api", kwargs={"slug": survey.slug})
+    )
+    assert map_resp.status_code == 200
+    map_ids = [int(q["id"]) for q in map_resp.json()["questions"]]
+    assert map_ids == [q_a.id, q_b.id]
+
+    # Preview should match map
+    preview_resp = client.get(reverse("surveys:preview", kwargs={"slug": survey.slug}))
+    assert preview_resp.status_code == 200
+    preview_ids = [q.id for q in list(preview_resp.context["questions"])]
+    assert preview_ids == map_ids
+
+    # Live take should also match map (use non-owner access path)
+    client.logout()
+    take_resp = client.get(reverse("surveys:take", kwargs={"slug": survey.slug}))
+    assert take_resp.status_code == 200
+    take_ids = [q.id for q in list(take_resp.context["questions"])]
+    assert take_ids == map_ids
+
+    # And live should carry branching_config in this same order
+    branching_config = json.loads(take_resp.context["branching_config"])
+    assert branching_config["questions"] == [str(i) for i in map_ids]
+
+
+@pytest.mark.django_db
+def test_preview_and_take_match_groups_page_order_when_group_order_is_partial(client):
+    owner = User.objects.create_user(username="owner-partial", password="x")
+    org = Organization.objects.create(name="Org", owner=owner)
+
+    survey = Survey.objects.create(
+        owner=owner,
+        organization=org,
+        name="Partial Group Order",
+        slug="partial-group-order",
+        status=Survey.Status.PUBLISHED,
+        visibility=Survey.Visibility.PUBLIC,
+    )
+
+    # IDs increase in this creation order: Zulu, Mike, Alpha.
+    group_zulu = QuestionGroup.objects.create(name="Zulu", owner=owner)
+    group_mike = QuestionGroup.objects.create(name="Mike", owner=owner)
+    group_alpha = QuestionGroup.objects.create(name="Alpha", owner=owner)
+    survey.question_groups.add(group_zulu, group_mike, group_alpha)
+
+    # Partial saved order: one explicit group + one stale id.
+    # Remaining groups should follow same fallback as /groups/ page.
+    style = survey.style or {}
+    style["group_order"] = [group_zulu.id, 999999]
+    survey.style = style
+    survey.save(update_fields=["style"])
+
+    SurveyQuestion.objects.create(
+        survey=survey,
+        group=group_zulu,
+        text="Z question",
+        type=SurveyQuestion.Types.TEXT,
+        order=0,
+    )
+    SurveyQuestion.objects.create(
+        survey=survey,
+        group=group_mike,
+        text="M question",
+        type=SurveyQuestion.Types.TEXT,
+        order=1,
+    )
+    SurveyQuestion.objects.create(
+        survey=survey,
+        group=group_alpha,
+        text="A question",
+        type=SurveyQuestion.Types.TEXT,
+        order=2,
+    )
+
+    client.force_login(owner)
+
+    groups_resp = client.get(reverse("surveys:groups", kwargs={"slug": survey.slug}))
+    assert groups_resp.status_code == 200
+    groups_page_order = [g.name for g in list(groups_resp.context["groups"])]
+    assert groups_page_order == ["Zulu", "Alpha", "Mike"]
+
+    preview_resp = client.get(reverse("surveys:preview", kwargs={"slug": survey.slug}))
+    assert preview_resp.status_code == 200
+    preview_group_order = _group_sequence(list(preview_resp.context["questions"]))
+    assert preview_group_order == groups_page_order
+
+    client.logout()
+    take_resp = client.get(reverse("surveys:take", kwargs={"slug": survey.slug}))
+    assert take_resp.status_code == 200
+    take_group_order = _group_sequence(list(take_resp.context["questions"]))
+    assert take_group_order == groups_page_order

--- a/checktick_app/surveys/views.py
+++ b/checktick_app/surveys/views.py
@@ -1157,22 +1157,7 @@ def survey_detail(request: HttpRequest, slug: str) -> HttpResponse:
         survey.questions.select_related("group").prefetch_related("images").all()
     )
     qs = _order_questions_by_group(survey, all_questions)
-
-    # Mark questions that have SHOW conditions (should be hidden by default)
-    questions_with_show_conditions = set(
-        SurveyQuestionCondition.objects.filter(
-            target_question__survey=survey, action=SurveyQuestionCondition.Action.SHOW
-        ).values_list("target_question_id", flat=True)
-    )
-
-    for i, q in enumerate(qs, start=1):
-        setattr(q, "idx", i)
-        prev_gid = qs[i - 2].group_id if i - 2 >= 0 else None
-        next_gid = qs[i].group_id if i < len(qs) else None
-        curr_gid = q.group_id
-        setattr(q, "group_start", bool(curr_gid and curr_gid != prev_gid))
-        setattr(q, "group_end", bool(curr_gid and curr_gid != next_gid))
-        setattr(q, "has_show_condition", q.id in questions_with_show_conditions)
+    _annotate_question_render_sequence(survey, qs)
     has_patient_template = any(
         getattr(q, "type", None) == SurveyQuestion.Types.TEMPLATE_PATIENT for q in qs
     )
@@ -1270,22 +1255,7 @@ def survey_preview(request: HttpRequest, slug: str) -> HttpResponse:
     )
     qs = _order_questions_by_group(survey, all_questions)
     _inject_dataset_options(qs)
-
-    # Mark questions that have SHOW conditions (should be hidden by default)
-    questions_with_show_conditions = set(
-        SurveyQuestionCondition.objects.filter(
-            target_question__survey=survey, action=SurveyQuestionCondition.Action.SHOW
-        ).values_list("target_question_id", flat=True)
-    )
-
-    for i, q in enumerate(qs, start=1):
-        setattr(q, "idx", i)
-        prev_gid = qs[i - 2].group_id if i - 2 >= 0 else None
-        next_gid = qs[i].group_id if i < len(qs) else None
-        curr_gid = q.group_id
-        setattr(q, "group_start", bool(curr_gid and curr_gid != prev_gid))
-        setattr(q, "group_end", bool(curr_gid and curr_gid != next_gid))
-        setattr(q, "has_show_condition", q.id in questions_with_show_conditions)
+    _annotate_question_render_sequence(survey, qs)
     patient_group, demographics_fields = _get_patient_group_and_fields(survey)
     prof_group, professional_fields, professional_ods = (
         _get_professional_group_and_fields(survey)
@@ -1443,16 +1413,61 @@ def _build_branching_config(questions: list[SurveyQuestion]) -> dict[str, Any]:
     return config
 
 
+def _resolved_group_order_ids(survey: Survey) -> list[int]:
+    """Return group IDs in the same display order as the /groups page.
+
+    Order rule:
+    1) Explicit IDs from ``survey.style['group_order']`` (valid IDs only)
+    2) Remaining groups sorted by name (case-insensitive), then id
+    """
+    groups = list(survey.question_groups.only("id", "name").all())
+    groups_map = {g.id: g for g in groups}
+
+    style = survey.style or {}
+    raw_order = style.get("group_order", [])
+    explicit_ids: list[int] = []
+    if isinstance(raw_order, list):
+        for gid in raw_order:
+            if str(gid).isdigit():
+                gid_int = int(gid)
+                if gid_int in groups_map and gid_int not in explicit_ids:
+                    explicit_ids.append(gid_int)
+
+    remaining = sorted(
+        (g for g in groups if g.id not in explicit_ids),
+        key=lambda g: ((g.name or "").lower(), g.id),
+    )
+    return explicit_ids + [g.id for g in remaining]
+
+
+def _annotate_question_render_sequence(
+    survey: Survey, questions: list[SurveyQuestion]
+) -> list[SurveyQuestion]:
+    """Attach rendering helper attrs consumed by ``surveys/detail.html``."""
+    questions_with_show_conditions = set(
+        SurveyQuestionCondition.objects.filter(
+            target_question__survey=survey,
+            action=SurveyQuestionCondition.Action.SHOW,
+        ).values_list("target_question_id", flat=True)
+    )
+
+    for i, q in enumerate(questions, start=1):
+        setattr(q, "idx", i)
+        prev_gid = questions[i - 2].group_id if i - 2 >= 0 else None
+        next_gid = questions[i].group_id if i < len(questions) else None
+        curr_gid = q.group_id
+        setattr(q, "group_start", bool(curr_gid and curr_gid != prev_gid))
+        setattr(q, "group_end", bool(curr_gid and curr_gid != next_gid))
+        setattr(q, "has_show_condition", q.id in questions_with_show_conditions)
+
+    return questions
+
+
 def _order_questions_by_group(
     survey: Survey, questions: list[SurveyQuestion]
 ) -> list[SurveyQuestion]:
-    """Order questions by group position (from survey.style['group_order']), then by question.order within each group.
-
-    This ensures that when groups are reordered via drag-and-drop, questions appear in the correct sequence
-    without breaking question-to-question branching logic.
-    """
-    style = survey.style or {}
-    group_order = style.get("group_order", [])
+    """Order questions by group position, then by question.order within each group."""
+    group_order = _resolved_group_order_ids(survey)
 
     # Separate questions by group
     grouped_questions: dict[int | None, list[SurveyQuestion]] = {}
@@ -1468,18 +1483,27 @@ def _order_questions_by_group(
     for group_id in grouped_questions:
         grouped_questions[group_id].sort(key=lambda q: (q.order, q.id))
 
-    # Build final ordered list
-    ordered = []
+    ordered: list[SurveyQuestion] = []
 
-    # Add groups in their specified order
+    # Add groups in resolved order
     for gid in group_order:
-        gid = int(gid) if str(gid).isdigit() else None
-        if gid and gid in grouped_questions:
+        if gid in grouped_questions:
             ordered.extend(grouped_questions[gid])
             del grouped_questions[gid]
 
-    # Add any remaining groups not in group_order (sorted by group_id)
-    for gid in sorted(grouped_questions.keys()):
+    # Any remaining (e.g. orphaned group refs) sorted by group name then id
+    remaining_group_ids = sorted(
+        grouped_questions.keys(),
+        key=lambda gid: (
+            (
+                (grouped_questions[gid][0].group.name or "").lower()
+                if grouped_questions[gid] and grouped_questions[gid][0].group
+                else ""
+            ),
+            gid,
+        ),
+    )
+    for gid in remaining_group_ids:
         ordered.extend(grouped_questions[gid])
 
     # Add ungrouped questions at the end, sorted by order
@@ -4307,15 +4331,10 @@ def _handle_participant_submission(
 
     # GET: render using existing detail template
     _prepare_question_rendering(survey)
-    qs = list(survey.questions.select_related("group", "dataset").all())
+    all_questions = list(survey.questions.select_related("group", "dataset").all())
+    qs = _order_questions_by_group(survey, all_questions)
     _inject_dataset_options(qs)
-    for i, q in enumerate(qs, start=1):
-        setattr(q, "idx", i)
-        prev_gid = qs[i - 2].group_id if i - 2 >= 0 else None
-        next_gid = qs[i].group_id if i < len(qs) else None
-        curr_gid = q.group_id
-        setattr(q, "group_start", bool(curr_gid and curr_gid != prev_gid))
-        setattr(q, "group_end", bool(curr_gid and curr_gid != next_gid))
+    _annotate_question_render_sequence(survey, qs)
     patient_group, demographics_fields = _get_patient_group_and_fields(survey)
     prof_group, professional_fields, professional_ods = (
         _get_professional_group_and_fields(survey)
@@ -4331,9 +4350,13 @@ def _handle_participant_submission(
         style["theme_css_light"] = _sanitize_css(style.get("theme_css_light") or "")
         style["theme_css_dark"] = _sanitize_css(style.get("theme_css_dark") or "")
         survey.style = style
+    # Build branching configuration for client-side logic
+    branching_config = _build_branching_config(qs)
+
     ctx = {
         "survey": survey,
         "questions": qs,
+        "branching_config": json.dumps(branching_config),
         "show_patient_details": show_patient_details,
         "demographics_fields": demographics_fields,
         "demographic_defs": DEMOGRAPHIC_FIELD_DEFS,
@@ -4568,15 +4591,12 @@ def survey_groups(request: HttpRequest, slug: str) -> HttpResponse:
             "surveyquestion", filter=models.Q(surveyquestion__survey=survey)
         )
     )
-    # Apply explicit saved order if present in survey.style
-    order_ids = []
-    style = survey.style or {}
-    if isinstance(style.get("group_order"), list):
-        order_ids = [int(gid) for gid in style["group_order"] if str(gid).isdigit()]
+    # Apply saved order with same fallback semantics used in runtime rendering
+    order_ids = _resolved_group_order_ids(survey)
     groups_map = {g.id: g for g in groups_qs}
     ordered = [groups_map[g_id] for g_id in order_ids if g_id in groups_map]
     remaining = [g for g in groups_qs if g.id not in order_ids]
-    groups = ordered + sorted(remaining, key=lambda g: g.name.lower())
+    groups = ordered + sorted(remaining, key=lambda g: ((g.name or "").lower(), g.id))
     # Apply style overrides so navigation reflects survey branding while managing groups
     style = survey.style or {}
     brand_overrides = {

--- a/docs/branching-technical.md
+++ b/docs/branching-technical.md
@@ -8,26 +8,27 @@ Technical documentation for developers implementing or extending branching logic
 
 ## Database Models
 
-### Condition Model
+### SurveyQuestionCondition Model
 
-The `Condition` model stores branching logic rules:
+The `SurveyQuestionCondition` model stores branching rules:
 
 ```python
-class Condition(models.Model):
-    question = models.ForeignKey(Question)  # The question this condition applies to
-    source_question = models.ForeignKey(Question)  # The question being checked
-    expected_value = models.CharField()  # The answer that triggers this condition
-    action = models.CharField(choices=ACTION_CHOICES)  # What to do when matched
-    target_question = models.ForeignKey(Question, null=True)  # Where to jump/skip to
-    order = models.IntegerField()  # Evaluation order for multiple conditions
+class SurveyQuestionCondition(models.Model):
+    question = models.ForeignKey(SurveyQuestion, related_name="conditions")
+    operator = models.CharField(choices=["eq", "neq", "contains", "gt", ...])
+    value = models.CharField(blank=True)
+    target_question = models.ForeignKey(SurveyQuestion, null=True, blank=True)
+    action = models.CharField(choices=["show", "jump_to", "skip", "end_survey"])
+    order = models.PositiveIntegerField(default=0)
+    description = models.CharField(blank=True)
 ```
 
 **Action Types:**
 
-- `SHOW` - Display the next question
-- `JUMP_TO` - Skip ahead to target_question
-- `SKIP` - Hide the next question
-- `END_SURVEY` - Complete the survey
+- `show` - Display target question when condition matches (hidden by default)
+- `jump_to` - Skip forward to target question
+- `skip` - Hide target question when condition matches
+- `end_survey` - End survey flow
 
 ### CollectionDefinition Model
 
@@ -35,43 +36,46 @@ Collections (groups) can be marked as repeating:
 
 ```python
 class CollectionDefinition(models.Model):
-    survey = models.ForeignKey(Survey)
-    name = models.CharField()
-    order = models.IntegerField()
-    max_count = models.IntegerField(null=True, blank=True)  # Null = unlimited
-    parent = models.ForeignKey('self', null=True)  # For nested collections
+    survey = models.ForeignKey(Survey, related_name="collections")
+    key = models.SlugField()  # unique per survey
+    name = models.CharField(max_length=255)
+    cardinality = models.CharField(choices=["one", "many"], default="many")
+    min_count = models.PositiveIntegerField(default=0)
+    max_count = models.PositiveIntegerField(null=True, blank=True)  # Null = unlimited
+    parent = models.ForeignKey("self", null=True, blank=True, related_name="children")
 ```
 
 ### CollectionItem Model
 
-Links questions or collections to their parent collection:
+Links question groups or child collections to a parent collection:
 
 ```python
 class CollectionItem(models.Model):
-    collection = models.ForeignKey(CollectionDefinition)
-    question = models.ForeignKey(Question, null=True)
-    nested_collection = models.ForeignKey(CollectionDefinition, null=True)
-    order = models.IntegerField()
+    collection = models.ForeignKey(CollectionDefinition, related_name="items")
+    item_type = models.CharField(choices=["group", "collection"])
+    group = models.ForeignKey(QuestionGroup, null=True, blank=True)
+    child_collection = models.ForeignKey(CollectionDefinition, null=True, blank=True)
+    order = models.PositiveIntegerField(default=0)
 ```
 
 **Rules:**
 
-- Either `question` or `nested_collection` must be set (not both)
+- Exactly one of `group` or `child_collection` must be set
 - Collections can be nested one level deep
-- Order determines the display sequence
+- `order` determines item order *within the collection definition*
 
 ## Relationships
 
-### Question → Conditions
+### SurveyQuestion → Conditions
 
-A question can have multiple conditions checked against it:
+A survey question can have multiple branching conditions:
 
 ```python
-# Conditions that check this question's answer
-source_conditions = question.source_conditions.all()
+# Outgoing conditions triggered by this question's answer
+outgoing_conditions = question.conditions.all()
 
-# Conditions that control whether this question appears
-target_conditions = question.condition_set.all()
+# Incoming conditions that point to this question
+incoming_conditions = question.incoming_conditions.all()
 ```
 
 ### Collections Hierarchy
@@ -79,12 +83,34 @@ target_conditions = question.condition_set.all()
 ```
 Survey
  └── CollectionDefinition (max_count=3)
-      ├── CollectionItem → Question 1
-      ├── CollectionItem → Question 2
-      └── CollectionItem → Nested CollectionDefinition
-           ├── CollectionItem → Question 3
-           └── CollectionItem → Question 4
+      ├── CollectionItem → Group A
+      ├── CollectionItem → Group B
+      └── CollectionItem → Child CollectionDefinition
+           ├── CollectionItem → Group C
+           └── CollectionItem → Group D
 ```
+
+## Runtime Ordering Contract
+
+To keep authoring and runtime consistent, ordering is derived through a shared pipeline in `checktick_app/surveys/views.py`:
+
+- `_resolved_group_order_ids(survey)`
+  - Uses `survey.style["group_order"]` first
+  - Filters stale/non-existent IDs
+  - Appends remaining groups sorted by name (case-insensitive), then id
+- `_order_questions_by_group(survey, questions)`
+  - Applies resolved group order
+  - Orders questions within each group by `(question.order, id)`
+- `_annotate_question_render_sequence(survey, questions)`
+  - Annotates `idx`, `group_start`, `group_end`, `has_show_condition`
+
+This same ordering is used by:
+
+- Survey Map API (`branching_data_api`)
+- Preview (`/surveys/{slug}/preview/`)
+- Live participant routes (`/take/`, `/take/unlisted/...`, `/take/token/...`)
+
+Result: **Survey Map = Preview = Live** for question-group sequence.
 
 ## API Endpoints
 
@@ -92,7 +118,7 @@ Survey
 
 **Endpoint:** `GET /surveys/{slug}/builder/api/branching-data/`
 
-Returns complete branching structure for visualization:
+Returns ordered branching structure for visualization:
 
 ```json
 {
@@ -100,6 +126,7 @@ Returns complete branching structure for visualization:
     {
       "id": "123",
       "text": "Question text",
+      "full_text": "Full question text",
       "order": 0,
       "group_name": "Demographics",
       "group_id": "456"
@@ -108,18 +135,19 @@ Returns complete branching structure for visualization:
   "conditions": {
     "123": [
       {
-        "source_question_text": "Previous question",
-        "expected_value": "Yes",
-        "action": "SHOW",
+        "operator": "eq",
+        "value": "Yes",
+        "action": "show",
         "target_question": "789",
-        "summary": "When 'Previous question' = 'Yes': Show next question"
+        "description": "",
+        "summary": "equals Yes"
       }
     ]
   },
   "group_repeats": {
     "456": {
       "is_repeated": true,
-      "count": 5  // or null for unlimited
+      "count": 5
     }
   }
 }
@@ -129,18 +157,20 @@ Returns complete branching structure for visualization:
 
 ### Condition Management
 
-**Create:** `POST /surveys/{slug}/builder/question/{qid}/conditions/`
-**Update:** `PUT /surveys/{slug}/builder/question/{qid}/conditions/{cid}/`
-**Delete:** `DELETE /surveys/{slug}/builder/question/{qid}/conditions/{cid}/`
+**Create:** `POST /surveys/{slug}/builder/questions/{qid}/conditions/create`
+**Update:** `POST /surveys/{slug}/builder/questions/{qid}/conditions/{cid}/update`
+**Delete:** `POST /surveys/{slug}/builder/questions/{qid}/conditions/{cid}/delete`
 
 Request body for create/update:
 
 ```json
 {
-  "source_question": 123,
-  "expected_value": "Yes",
-  "action": "JUMP_TO",
-  "target_question": 456
+  "operator": "eq",
+  "value": "Yes",
+  "action": "jump_to",
+  "target_question": 456,
+  "order": 0,
+  "description": ""
 }
 ```
 
@@ -223,23 +253,20 @@ if (p) colors.primary = `hsl(${p})`;
 ### Condition Syntax
 
 ```markdown
-## Source Question
+## Source Question {source-question}
 (mc_single)
 - Option A
 - Option B
--> Option A : {target-question-name}
--> Option B : SKIP
+? when equals "Option A" -> {target-question}
+? when equals "Option B" -> {another-target}
 ```
 
 **Syntax Rules:**
 
-- `->` prefix for condition lines
-- Format: `-> [value] : [action]`
-- Actions:
-  - `{question-name}` - Jump to question
-  - `SKIP` - Skip next question
-  - `END` - End survey
-  - Default (no action) - Show next
+- `? when` prefix for condition lines
+- Format: `? when <operator> <value> -> {target-id}`
+- Common operators: `equals`, `not_equals`, `contains`, `greater_than`, `less_than`
+- Targets can be question IDs (or group IDs during import, resolved to the first question in that group)
 
 ### Repeat Syntax
 
@@ -267,98 +294,47 @@ REPEAT-5
 
 ### Condition Evaluation
 
-When rendering a survey, conditions are evaluated in order:
+Client-side branching uses `checktick_app/static/js/branching.js` with config produced by `_build_branching_config(...)`.
 
-```python
-def should_show_question(question, user_responses):
-    conditions = question.condition_set.all().order_by('order')
+Supported actions and behavior:
 
-    for condition in conditions:
-        source_value = user_responses.get(condition.source_question.id)
+- `show`: target question is hidden by default, shown when an incoming SHOW condition matches
+- `jump_to`: hides questions between current and target in configured question order
+- `skip`: hides the target question when condition matches
+- `end_survey`: hides subsequent questions after trigger
 
-        if source_value == condition.expected_value:
-            if condition.action == 'SHOW':
-                return True
-            elif condition.action == 'JUMP_TO':
-                return condition.target_question
-            elif condition.action == 'SKIP':
-                return False
-            elif condition.action == 'END_SURVEY':
-                return 'END'
-
-    return True  # Default: show question
-```
+Condition evaluation follows question order from `branching_config.questions`, generated from the same runtime ordering pipeline used by Survey Map, preview, and live routes.
 
 ### Collection Instances
 
-When a user adds a repeat instance:
+Collection definitions remain backend entities for repeat metadata and response structuring.
 
-```python
-# Create new response instance
-instance = ResponseInstance.objects.create(
-    response=response,
-    collection=collection_definition,
-    instance_number=collection_definition.get_next_instance_number(response)
-)
-
-# Copy questions for this instance
-for item in collection_definition.collectionitem_set.all():
-    if item.question:
-        QuestionResponse.objects.create(
-            response=response,
-            question=item.question,
-            collection_instance=instance
-        )
-```
+Important: participant page rendering order is currently driven by the shared question-order pipeline (`group_order` + per-group question order), not by traversing `CollectionItem` trees.
 
 ## Testing
 
 ### Test Files
 
-- `test_bulk_upload_branching.py` - Markdown import with conditions
-- `test_conditions.py` - Condition model and evaluation
-- `test_collections.py` - Repeating groups
+- `test_bulk_upload_branching.py` - Markdown import with branching and repeats
+- `test_groups_reorder.py` - Group ordering persistence
+- `test_groups_repeats.py` - Repeat creation/edit/removal
+- `test_collections_models.py` - Collection model constraints
+- `test_runtime_ordering_consistency.py` - Survey Map/Preview/Live ordering consistency
 
 ### Key Test Scenarios
 
-**Branching:**
+**Branching + ordering consistency:**
 
-- Condition creation via API
-- Multiple conditions on one question
-- Invalid target questions
-- Circular dependencies
-- Conditions across groups
+- Survey Map ordering matches Preview ordering
+- Survey Map ordering matches live `/take/*` ordering
+- Partial/stale `group_order` IDs produce the same fallback order as `/groups/`
+- Branching config question order follows runtime ordered question list
 
-**Repeats:**
+Relevant coverage includes:
 
-- Unlimited repeats
-- Limited repeats (reaching max)
-- Nested collections
-- Collection ordering
-- Response instance creation
-
-### Example Test
-
-```python
-def test_condition_evaluation():
-    # Create survey with branching
-    q1 = Question.objects.create(text="Trigger question", type="mc_single")
-    q2 = Question.objects.create(text="Target question", type="text")
-
-    Condition.objects.create(
-        question=q2,
-        source_question=q1,
-        expected_value="Yes",
-        action="SHOW"
-    )
-
-    # Test evaluation
-    response = {"q1": "Yes"}
-    assert should_show_question(q2, response) == True
-
-    response = {"q1": "No"}
-    assert should_show_question(q2, response) == False
-```
+- `checktick_app/surveys/tests/test_runtime_ordering_consistency.py`
+- `checktick_app/surveys/tests/test_groups_reorder.py`
+- `checktick_app/surveys/tests/test_xss_survey_take.py`
 
 ## Performance Considerations
 
@@ -373,12 +349,12 @@ The branching data API performs:
 **Optimization:**
 
 ```python
-# Prefetch related data
-questions = Question.objects.filter(
+# Prefetch related data for branching visualisation
+questions = SurveyQuestion.objects.filter(
     survey=survey
 ).select_related('group').prefetch_related(
-    Prefetch('condition_set',
-             queryset=Condition.objects.select_related('source_question'))
+    'conditions',
+    'conditions__target_question'
 )
 ```
 

--- a/docs/publish-and-collection.md
+++ b/docs/publish-and-collection.md
@@ -17,6 +17,17 @@ From your survey dashboard, click **Publish Settings** to configure:
 - **Who can access it**: Choose a visibility mode (see below)
 - **Security features**: Enable CAPTCHA for anonymous surveys
 
+## Question Order, Preview, and Live Publication
+
+Question-group order is now consistent across authoring and participant views.
+
+- The **Survey Map** on the `/groups/` page is the source of truth for display sequence.
+- Group order comes from `survey.style.group_order` (set when users reorder groups), with a safe fallback for missing/stale IDs:
+  1. groups explicitly listed in `group_order`
+  2. any remaining groups sorted by name (A→Z)
+- **Preview** (`/surveys/{slug}/preview/`) and **live survey routes** (`/take/`, `/take/unlisted/...`, `/take/token/...`) use the same runtime ordering and branching configuration.
+- Publishing does **not** reshuffle questions/groups; publication uses the current authored structure.
+
 ## Choosing a Visibility Mode
 
 CheckTick provides four ways to share your survey, from most secure to most open:
@@ -333,6 +344,12 @@ CheckTick includes enterprise-grade security:
 - Tokens can only be used once
 - Generate a new token for the participant
 - Check if the token has expired
+
+**"Groups appear in different order in preview vs live"**
+
+- Preview and live now share the same ordering pipeline.
+- Recheck the order in **Groups** (Survey Map reflects runtime order).
+- If order still looks wrong after major edits (clone/import/translation), save group order again from `/groups/` to refresh `group_order` state.
 
 **"CAPTCHA failed"**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "checktick"
-version = "0.5.1"
+version = "0.5.2"
 description = "Secure, server-rendered survey platform for medical audit and research"
 authors = ["CheckTick Maintainers <simon@eatyourpeas.co.uk>"]
 readme = "README.md"


### PR DESCRIPTION
## Description

### Problem and diagnosis

After authoring a survey, users could reorder question groups in `/groups/` (visible in the Survey Map), but that order was not applied consistently at runtime:

- Survey Map and Preview used group-aware ordering (`_order_questions_by_group`), while live participant routes (`/take/*`) rendered raw `survey.questions` ordering.
- Fallback behavior also diverged: when `survey.style.group_order` was partial or stale, Preview/Map could fall back by group id while `/groups/` UI fell back by group name.
- Branching depended on rendered question order, so inconsistent ordering could also affect jump/skip/show behavior between Preview and Live.

In short, the same survey could appear in different group/question sequences across Survey Map, Preview, and live publication.

This PR fixes that by making ordering deterministic and shared across all three surfaces.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [x] 🔧 Maintenance (dependency updates, code cleanup, etc.)
- [ ] 🚀 Performance improvement
- [ ] 🔒 Security enhancement
- [x] 🧪 Test coverage improvement

## Related Issues

Relates to ordering inconsistency reported for published and preview survey rendering.

## Changes Made

### 1) Runtime ordering contract unified (backend)

In `checktick_app/surveys/views.py`:

- Added `_resolved_group_order_ids(survey)`:
  - Uses `survey.style["group_order"]` first
  - Filters invalid/stale/non-existent IDs
  - Appends remaining groups sorted by `(name.lower(), id)`
- Updated `_order_questions_by_group(...)` to always use resolved IDs and consistent fallback ordering.
- Added `_annotate_question_render_sequence(...)` to centralize question render metadata:
  - `idx`, `group_start`, `group_end`, `has_show_condition`

### 2) Preview and live now use the same ordered pipeline

- `survey_preview` now uses shared ordering + shared annotation helper.
- Live participant GET rendering (`_handle_participant_submission` used by `/take/`, `/take/unlisted/...`, `/take/token/...`) now uses:
  - `_order_questions_by_group(...)`
  - `_annotate_question_render_sequence(...)`
- Live participant context now includes `branching_config` (same style as Preview).

### 3) `/groups/` ordering semantics aligned with runtime

- `survey_groups` now uses `_resolved_group_order_ids(survey)` so UI order fallback logic matches runtime order fallback logic.

### 4) TDD coverage added first, then implementation

Added `checktick_app/surveys/tests/test_runtime_ordering_consistency.py`:

- `test_survey_map_preview_take_share_same_question_order`
- `test_preview_and_take_match_groups_page_order_when_group_order_is_partial`

These tests were introduced in failing state first (red), then implementation made them pass (green).

### 5) Documentation updated

- `docs/publish-and-collection.md`
  - Added explicit section: **Question Order, Preview, and Live Publication**
  - Added troubleshooting note for apparent ordering mismatch
- `docs/branching-technical.md`
  - Updated model/endpoint examples to current code concepts
  - Added **Runtime Ordering Contract** section
  - Clarified Survey Map/Preview/Live consistency guarantee
  - Updated branching API payload examples and test references

### 6) Version bump

- Included version update in `pyproject.toml` (`0.5.2`)

## Component/Area

- [x] Backend (Django/Python)
- [ ] Frontend (HTML/CSS/JS)
- [ ] API (DRF endpoints)
- [ ] Database (models/migrations)
- [ ] Authentication/Security
- [x] Tests
- [x] Documentation
- [ ] CI/CD
- [ ] Docker/Deployment

## Healthcare/Clinical Context

**Use Case**: Clinical audit / survey authoring and publication.

**Benefit**: Survey authors can trust that the authored group order shown in Survey Map is what participants see in both Preview and live collection, reducing risk of logic drift and respondent confusion.

## Security Considerations

- [x] No security impact
- [ ] Security improvement
- [ ] Requires security review
- [ ] Changes authentication/authorization
- [ ] Modifies data encryption/handling
- [ ] Updates audit logging

**Details**: Existing XSS/branching serialization protections remain in place; focused regression tests around survey-take/branching passed.

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes (see details below)

**Migration Notes**: No migration required.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing completed
- [x] Tested with healthcare use cases
- [ ] Tested on hosted environment
- [x] Tested with self-hosted deployment

**Test Summary**:

Targeted TDD tests:

- `docker compose exec -T web python -m pytest -n auto --ignore=tests/test_accessibility.py checktick_app/surveys/tests/test_runtime_ordering_consistency.py`
  - Result: `2 passed`

Focused regression suite:

- `docker compose exec -T web python -m pytest -n auto --ignore=tests/test_accessibility.py checktick_app/surveys/tests/test_groups_reorder.py checktick_app/surveys/tests/test_groups_ssr.py checktick_app/surveys/tests/test_progress_tracking.py checktick_app/surveys/tests/test_xss_survey_take.py checktick_app/surveys/tests/test_publish.py checktick_app/surveys/tests/test_permissions.py`
  - Result: `70 passed`

Lint/format (container equivalent of `s/lint`):

- `docker compose exec -T web bash -c "poetry run ruff check --fix . && poetry run black . && poetry run isort ."`

## Performance Impact

- [x] No performance impact
- [ ] Performance improvement
- [ ] Potential performance regression (justified below)

**Details**: Ordering resolution adds lightweight in-memory ordering over survey groups/questions already loaded for render paths.

## Documentation

- [ ] No documentation needed
- [x] Documentation updated in this PR
- [ ] Documentation update needed (separate PR/issue)
- [ ] API documentation updated
- [x] User guide updated

## Deployment Notes

- [x] No special deployment considerations
- [ ] Requires database migration
- [ ] Requires environment variable changes
- [ ] Requires new dependencies
- [ ] Requires configuration changes

**Notes**: Safe backend/template/docs update, no schema changes.

## Additional Notes

Commits in this branch:

- `a5e7800` test(surveys): add TDD coverage for map/preview/live ordering consistency
- `1016efb` fix(surveys): align preview/live ordering and branching with survey map
- `aff48aa` docs(surveys): document ordering consistency and update branching/publish guidance
