### PR TITLE
fix/password-reset-template-formatting-wording

### DIFF
--- a/checktick_app/core/tests/test_email_confirmation.py
+++ b/checktick_app/core/tests/test_email_confirmation.py
@@ -238,6 +238,49 @@ class TestSignupWithEmailConfirmation(TestCase):
         # Confirmation token should be created
         self.assertTrue(EmailConfirmationToken.objects.filter(user=user).exists())
 
+    def test_signup_confirmation_email_includes_brand_name(self):
+        """Test that signup confirmation email subject includes the platform brand name."""
+        from django.core import mail
+
+        response = self.client.post(
+            reverse("core:signup"),
+            {
+                "email": "brandtest@example.com",
+                "password1": "complexpassword123!",
+                "password2": "complexpassword123!",
+            },
+        )
+
+        # Should redirect to home after signup
+        self.assertEqual(response.status_code, 302)
+
+        # Check that confirmation email was sent
+        self.assertEqual(len(mail.outbox), 2)  # Confirmation + welcome email
+
+        # Find the confirmation email
+        confirmation_email = None
+        for email in mail.outbox:
+            if "confirm" in email.subject.lower():
+                confirmation_email = email
+                break
+
+        self.assertIsNotNone(confirmation_email, "Confirmation email should be sent")
+
+        # Subject should include the brand name
+        self.assertIn(
+            "CheckTick",
+            confirmation_email.subject,
+            f"Expected brand name 'CheckTick' in subject, got: '{confirmation_email.subject}'",
+        )
+        self.assertIn("confirm", confirmation_email.subject.lower())
+
+        # Body should also include the brand name
+        self.assertIn(
+            "CheckTick",
+            confirmation_email.body,
+            "Expected brand name 'CheckTick' in email body",
+        )
+
 
 class TestProtectedFeaturesAccess(TestCase):
     """Test access to features that require email confirmation."""

--- a/checktick_app/core/tests/test_password_reset_flow.py
+++ b/checktick_app/core/tests/test_password_reset_flow.py
@@ -58,3 +58,44 @@ class TestPasswordResetFlow:
             "/accounts/login/", {"username": user.email, "password": new_password}
         )
         assert login.status_code == 302
+
+    def test_password_reset_email_subject_includes_brand_name(self, client, mailoutbox):
+        """Test that password reset email subject includes the platform brand name."""
+        unique_id = secrets.token_hex(8)
+        email = f"brand_test_{unique_id}@example.com"
+        user = User.objects.create_user(
+            username=email,
+            email=email,
+            password=secrets.token_urlsafe(12),
+        )
+        client.post(reverse("password_reset"), {"email": user.email})
+        assert len(mailoutbox) == 1
+        msg = mailoutbox[0]
+        # Subject should include the brand name (e.g., "CheckTick: Reset your password")
+        assert (
+            "CheckTick" in msg.subject
+        ), f"Expected brand name 'CheckTick' in subject, got: '{msg.subject}'"
+        assert "Reset your password" in msg.subject
+
+    def test_password_reset_email_body_includes_brand_name(self, client, mailoutbox):
+        """Test that password reset email body includes the platform brand name."""
+        unique_id = secrets.token_hex(8)
+        email = f"brand_body_{unique_id}@example.com"
+        user = User.objects.create_user(
+            username=email,
+            email=email,
+            password=secrets.token_urlsafe(12),
+        )
+        client.post(reverse("password_reset"), {"email": user.email})
+        assert len(mailoutbox) == 1
+        msg = mailoutbox[0]
+        # Plain text body should include the brand name
+        assert (
+            "CheckTick" in msg.body
+        ), "Expected brand name 'CheckTick' in plain text body"
+        # HTML alternative should also include the brand name
+        assert msg.alternatives, "Expected HTML alternative email"
+        html_content = msg.alternatives[0][0]
+        assert (
+            "CheckTick" in html_content
+        ), "Expected brand name 'CheckTick' in HTML body"

--- a/checktick_app/core/views.py
+++ b/checktick_app/core/views.py
@@ -911,8 +911,8 @@ class BrandedPasswordResetView(auth_views.PasswordResetView):
     email_template_name = "registration/password_reset_email.txt"
     html_email_template_name = "registration/password_reset_email.html"
 
-    def get_email_options(self):
-        opts = super().get_email_options()
+    def form_valid(self, form):
+        """Override to inject brand context into email templates."""
         # Use get_platform_branding() so brand includes colors/fonts needed by base_email.html.
         try:
             from checktick_app.core.email_utils import get_platform_branding
@@ -920,14 +920,14 @@ class BrandedPasswordResetView(auth_views.PasswordResetView):
             brand = get_platform_branding()
         except Exception:
             brand = {"title": getattr(settings, "BRAND_TITLE", "CheckTick")}
-        extra = opts.get("extra_email_context") or {}
-        merged = {
-            **extra,
+
+        # Inject brand context into extra_email_context
+        self.extra_email_context = {
+            **(self.extra_email_context or {}),
             "brand": brand,
             "site_url": getattr(settings, "SITE_URL", ""),
         }
-        opts["extra_email_context"] = merged
-        return opts
+        return super().form_valid(form)
 
 
 ## Removed DirectPasswordResetConfirmView to use Django's standard confirm flow.

--- a/checktick_app/templates/registration/password_reset_done.html
+++ b/checktick_app/templates/registration/password_reset_done.html
@@ -7,7 +7,6 @@
     <div class="card-body">
       <h1 class="card-title">{% trans "Check your email" %}</h1>
       <p class="opacity-80">{% trans "If an account exists with that email, we've sent a password reset link. Please follow the instructions to choose a new password." %}</p>
-      <p class="opacity-70 text-sm mt-2">{% trans "In development, the reset email is printed to the console." %}</p>
       <a href="/accounts/login/" class="btn btn-ghost mt-3">{% trans "Back to login" %}</a>
     </div>
   </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "checktick"
-version = "0.5.10"
+version = "0.5.11"
 description = "Secure, server-rendered survey platform for medical audit and research"
 authors = ["CheckTick Maintainers <simon@eatyourpeas.co.uk>"]
 readme = "README.md"


### PR DESCRIPTION
Refactors text in template to remove reference to development. Adds brand title missing from email headers