### PR TITLE
devops/vault-sealed

### DIFF
--- a/checktick_app/core/views.py
+++ b/checktick_app/core/views.py
@@ -1,10 +1,11 @@
-from decimal import Decimal
 import logging
 import os
+from decimal import Decimal
 
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth import login, views as auth_views
+from django.contrib.auth import login
+from django.contrib.auth import views as auth_views
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.hashers import make_password
 from django.db import transaction
@@ -284,7 +285,7 @@ def healthz(request):
 
         vault_health = VaultClient().health_check()
         if vault_health.get("sealed"):
-            logger.warning("healthz: Vault is sealed")
+            logger.error("healthz: Vault is sealed")
             status["vault"] = "sealed"
             status["status"] = "degraded"
             http_status = 503

--- a/checktick_app/core/views.py
+++ b/checktick_app/core/views.py
@@ -1,11 +1,10 @@
+from decimal import Decimal
 import logging
 import os
-from decimal import Decimal
 
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth import login
-from django.contrib.auth import views as auth_views
+from django.contrib.auth import login, views as auth_views
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.hashers import make_password
 from django.db import transaction

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "checktick"
-version = "0.5.11"
+version = "0.5.12"
 description = "Secure, server-rendered survey platform for medical audit and research"
 authors = ["CheckTick Maintainers <simon@eatyourpeas.co.uk>"]
 readme = "README.md"


### PR DESCRIPTION
Upgrades vault healthz to error in logs so that it shows up in openobserve and can be trapped in a notification