### PR TITLE
Fix login lockout behavior for shared IPs

### DIFF
--- a/checktick_app/core/tests/test_login_lockout.py
+++ b/checktick_app/core/tests/test_login_lockout.py
@@ -1,0 +1,113 @@
+import secrets
+
+from axes.models import AccessAttempt
+from django.urls import reverse
+import pytest
+
+LOGIN_IP = "203.0.113.42"
+PASSWORD = "correct-password-123"
+
+
+@pytest.fixture(autouse=True)
+def clear_axes_attempts():
+    """Keep Axes state isolated for these login-lockout tests."""
+    AccessAttempt.objects.all().delete()
+    yield
+    AccessAttempt.objects.all().delete()
+
+
+@pytest.fixture
+def known_user(django_user_model):
+    unique = secrets.token_hex(8)
+    email = f"lockout-{unique}@example.com"
+    return django_user_model.objects.create_user(
+        username=email,
+        email=email,
+        password=PASSWORD,
+    )
+
+
+@pytest.fixture
+def axes_login_settings(settings):
+    """Use production-like Axes behavior, without localhost whitelisting."""
+    settings.AXES_ENABLED = True
+    settings.AXES_IP_WHITELIST = []
+    settings.RATELIMIT_ENABLE = False
+    return settings
+
+
+def post_login(client, username, password, ip_address=LOGIN_IP):
+    return client.post(
+        reverse("login"),
+        {"username": username, "password": password},
+        REMOTE_ADDR=ip_address,
+    )
+
+
+@pytest.mark.django_db
+class TestLoginLockout:
+    def test_axes_locks_accounts_by_username_not_standalone_ip(self, settings):
+        """Account lockout should be based on the submitted email address.
+
+        IP-based credential-stuffing protection should be handled separately so a
+        shared office/NAT/proxy IP cannot force known users straight to the
+        account lockout page.
+        """
+        params = settings.AXES_LOCKOUT_PARAMETERS
+        assert params == [["username"]]
+        assert ["ip_address"] not in params
+        assert settings.AXES_RESET_ON_SUCCESS is True
+
+    def test_ip_failures_for_other_usernames_do_not_lock_known_account_immediately(
+        self, client, known_user, axes_login_settings
+    ):
+        """A saturated source IP must not consume a known account's own attempts."""
+        for index in range(axes_login_settings.AXES_FAILURE_LIMIT):
+            response = post_login(
+                client,
+                username=f"unknown-{index}-{secrets.token_hex(4)}@example.com",
+                password="wrong-password",
+            )
+            assert response.status_code in (
+                200,
+                axes_login_settings.AXES_HTTP_RESPONSE_CODE,
+            )
+
+        response = post_login(
+            client,
+            username=known_user.email,
+            password="wrong-password",
+        )
+
+        assert response.status_code == 200
+        assert b"Login" in response.content
+
+    def test_successful_login_resets_prior_failed_attempts(
+        self, client, known_user, axes_login_settings
+    ):
+        """A successful login should clear previous failures for that account."""
+        for _ in range(axes_login_settings.AXES_FAILURE_LIMIT - 1):
+            response = post_login(
+                client,
+                username=known_user.email,
+                password="wrong-password",
+            )
+            assert response.status_code == 200
+
+        response = post_login(
+            client,
+            username=known_user.email,
+            password=PASSWORD,
+        )
+        assert response.status_code == 302
+
+        client.logout()
+
+        response = post_login(
+            client,
+            username=known_user.email,
+            password="wrong-password",
+        )
+
+        assert response.status_code == 200
+        assert b"Login" in response.content

--- a/checktick_app/settings.py
+++ b/checktick_app/settings.py
@@ -518,14 +518,17 @@ CORS_URLS_REGEX = r"^/api/schema$"  # Only allow CORS on the schema endpoint
 # Axes configuration for brute-force protection
 AXES_FAILURE_LIMIT = 5
 AXES_COOLOFF_TIME = 1  # hour
-# Use a list-of-lists so axes tracks each dimension independently.
 # Users authenticate with their email address; Django's AuthenticationForm submits
-# it under the field name "username", so axes tracks it as the "username" credential.
-# AXES_USERNAME_FORM_FIELD defaults to "username", matching our EmailAuthenticationForm.
-# [["username"]] locks an email address after AXES_FAILURE_LIMIT failures regardless
-# of the attacker's IP, preventing bypass via IP rotation.
-# [["ip_address"]] additionally rate-limits credential-stuffing from a single IP.
-AXES_LOCKOUT_PARAMETERS = [["username"], ["ip_address"]]
+# it under the field name "username", so Axes tracks the account by that credential.
+# Keep account lockout scoped to the submitted email address only. A standalone
+# IP lockout causes legitimate users behind a shared NAT/proxy/VPN to be sent
+# directly to the account lockout page after unrelated failures from the same IP.
+# IP-based credential-stuffing protection should be handled separately with a
+# higher-threshold request rate limit rather than the account lockout mechanism.
+AXES_LOCKOUT_PARAMETERS = [["username"]]
+# Clear prior failed attempts after a successful login so a user does not remain
+# one typo away from lockout after proving they know the correct password.
+AXES_RESET_ON_SUCCESS = True
 # Disable axes for OIDC callbacks to avoid interference
 AXES_NEVER_LOCKOUT_WHITELIST = True
 AXES_IP_WHITELIST = ["127.0.0.1", "localhost"]

--- a/checktick_app/surveys/tests/test_account_enumeration.py
+++ b/checktick_app/surveys/tests/test_account_enumeration.py
@@ -19,9 +19,10 @@ Findings covered
 Brute-force lockout
 -------------------
 Also checks that ``AXES_LOCKOUT_PARAMETERS`` is configured as a list-of-lists
-so that axes tracks *username* and *IP* independently.  The previous flat-list
-format locked only on the combination (username AND ip_address), which allowed
-an attacker to bypass the per-account lockout by rotating source IP addresses.
+scoped to the submitted username/email address.  IP-based credential-stuffing
+protection should be handled separately so unrelated failures from a shared
+NAT/proxy/VPN IP cannot force legitimate users straight to the account lockout
+page.
 
 Timing side-channel (org_setup)
 --------------------------------
@@ -428,50 +429,46 @@ class TestSurveyUsersEnumeration:
 
 
 class TestAxesLockoutConfiguration:
-    """Verify that AXES_LOCKOUT_PARAMETERS is structured to prevent IP-rotation
-    bypass of per-account lockouts."""
+    """Verify that account lockout is scoped to submitted email address only."""
 
     def test_lockout_parameters_is_list_of_lists(self):
         """
         Users authenticate with their email address, submitted under the form
-        field named 'username' (Django's AuthenticationForm convention).  Axes
-        tracks lockouts using that field value, so 'username' in axes terms
+        field named 'username' (Django's AuthenticationForm convention). Axes
+        tracks lockouts using that field value, so 'username' in Axes terms
         means the user's email address in this application.
 
-        A flat list ``["username", "ip_address"]`` locks only on the
-        *combination*, letting an attacker rotate IPs to keep targeting the same
-        email address indefinitely.
-
-        The correct form ``[["username"], ["ip_address"]]`` tracks each
-        dimension independently, so hitting the limit on either one locks out.
+        Keep the list-of-lists structure expected by django-axes while avoiding
+        standalone IP account lockout. A separate ['ip_address'] dimension makes
+        unrelated failures from a shared NAT/proxy/VPN IP lock out legitimate
+        users before their own account has reached the failure limit.
         """
         params = settings.AXES_LOCKOUT_PARAMETERS
         assert isinstance(params, list), "AXES_LOCKOUT_PARAMETERS must be a list"
         for item in params:
             assert isinstance(item, list), (
                 f"AXES_LOCKOUT_PARAMETERS items must be lists (got {type(item).__name__!r}: {item!r}). "
-                "A flat list locks only on the combination; use a list-of-lists to lock independently."
+                "Use a list-of-lists so Axes treats each configured parameter set explicitly."
             )
 
-    def test_lockout_tracks_email_address_independently(self):
-        """The email address is submitted under the 'username' form field
-        (required by Django's AuthenticationForm).  It must appear as a
-        standalone axes tracking dimension so that IP rotation cannot bypass
-        a per-account lockout."""
+    def test_lockout_tracks_email_address(self):
+        """The email address must be the account lockout dimension."""
         params = settings.AXES_LOCKOUT_PARAMETERS
         standalone_keys = {frozenset(item) for item in params if isinstance(item, list)}
         assert frozenset(["username"]) in standalone_keys, (
-            "AXES_LOCKOUT_PARAMETERS must include ['username'] as a standalone "
-            "dimension.  In this app 'username' holds the email address; "
-            "locking by it independently prevents IP-rotation bypass."
+            "AXES_LOCKOUT_PARAMETERS must include ['username'] as the account "
+            "lockout dimension. In this app 'username' holds the email address."
         )
 
-    def test_lockout_tracks_ip_independently(self):
-        """IP address must appear as a standalone dimension to rate-limit
-        credential-stuffing targeting many email addresses from one source."""
+    def test_lockout_does_not_track_ip_as_account_lockout_dimension(self):
+        """Standalone IP lockout causes false account lockouts on shared IPs."""
         params = settings.AXES_LOCKOUT_PARAMETERS
         standalone_keys = {frozenset(item) for item in params if isinstance(item, list)}
-        assert frozenset(["ip_address"]) in standalone_keys, (
-            "AXES_LOCKOUT_PARAMETERS must include ['ip_address'] as a standalone "
-            "dimension to rate-limit credential-stuffing from a single IP."
+        assert frozenset(["ip_address"]) not in standalone_keys, (
+            "IP-based credential-stuffing protection should be implemented with "
+            "a separate request rate limit, not as an Axes account lockout dimension."
         )
+
+    def test_successful_login_resets_failed_attempts(self):
+        """Successful authentication should clear stale failed-attempt counters."""
+        assert settings.AXES_RESET_ON_SUCCESS is True

--- a/docs/compliance/pentest-remediation-response-AD24502.md
+++ b/docs/compliance/pentest-remediation-response-AD24502.md
@@ -243,16 +243,18 @@ The `font_css_url` field (used to load Google Fonts or self-hosted font styleshe
 
 **`django-axes` upgraded and reconfigured (v8.1.0):**
 
-`django-axes` is installed as both a Django app and middleware, placed before `AuthenticationMiddleware` so it intercepts requests before Django's own auth layer. The configuration:
+`django-axes` is installed as both a Django app and middleware. The configuration:
 
 ```python
 AXES_FAILURE_LIMIT = 5          # Lock after 5 consecutive failures
 AXES_COOLOFF_TIME = 1           # 1-hour cooldown
-AXES_LOCKOUT_PARAMETERS = [["username"], ["ip_address"]]
+AXES_LOCKOUT_PARAMETERS = [["username"]]
+AXES_RESET_ON_SUCCESS = True
 ```
 
 - `[["username"]]` locks a specific email address after 5 failures, **regardless of the attacker's IP** — preventing bypass via IP rotation/VPN cycling.
-- `[["ip_address"]]` independently rate-limits credential-stuffing from a single IP even across different usernames.
+- Account lockout deliberately does not use a standalone `[["ip_address"]]` dimension, because unrelated failures from a shared NAT/proxy/VPN IP can otherwise force legitimate users straight to the account lockout page.
+- `AXES_RESET_ON_SUCCESS` clears stale failed-attempt counters when a user proves they know the correct password.
 
 When triggered, the user sees `403_lockout.html` and receives an automated email notification (`checktick_app/core/signals.py` — `send_lockout_notification()`).
 
@@ -266,7 +268,7 @@ The `/api/token` JWT issuing endpoint no longer exists. It has been removed from
 
 | Item | Location |
 | :--- | :--- |
-| Axes configuration | `checktick_app/settings.py` — `AXES_FAILURE_LIMIT`, `AXES_COOLOFF_TIME`, `AXES_LOCKOUT_PARAMETERS` |
+| Axes configuration | `checktick_app/settings.py` — `AXES_FAILURE_LIMIT`, `AXES_COOLOFF_TIME`, `AXES_LOCKOUT_PARAMETERS`, `AXES_RESET_ON_SUCCESS` |
 | Lockout signal / email | `checktick_app/core/signals.py` — `send_lockout_notification()` |
 | Lockout template | `checktick_app/core/templates/403_lockout.html` |
 | `/api/token` removal confirmed | `checktick_app/api/urls.py` — router has no `token` or `obtain_token` entry |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "checktick"
-version = "0.6.4"
+version = "0.6.5"
 description = "Secure, server-rendered survey platform for medical audit and research"
 authors = ["CheckTick Maintainers <simon@eatyourpeas.co.uk>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Scope django-axes account lockout to the submitted username/email instead of standalone IP address
- Reset failed login counters after successful authentication
- Add regression tests for shared-IP false lockouts and successful-login reset behavior
- Update existing lockout configuration tests and compliance documentation

## Validation
- script -q /dev/null ./s/test --no-a11y --serial checktick_app/core/tests/test_login_lockout.py checktick_app/surveys/tests/test_account_enumeration.py -q
- script -q /dev/null ./s/lint

Closes #255