### PR TITLE
fix/readme-version-badge-drift

### DIFF
--- a/.github/workflows/update-version-badge.yml
+++ b/.github/workflows/update-version-badge.yml
@@ -1,0 +1,84 @@
+name: Update Version Badge
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "pyproject.toml"
+
+permissions:
+  contents: write
+
+jobs:
+  update-badge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Need full history to diff, and a token that can push back.
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from pyproject.toml
+        id: version
+        run: |
+          VERSION=$(python3 - <<'PY'
+          import tomllib
+          with open('pyproject.toml', 'rb') as f:
+              data = tomllib.load(f)
+          print(data['tool']['poetry']['version'])
+          PY
+          )
+          {
+            echo "version=$VERSION"
+            echo "Version: $VERSION"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Update README badge
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          python3 - <<'PY'
+          import os, re, sys
+
+          version = os.environ["VERSION"]
+          with open('README.md', 'r') as f:
+              content = f.read()
+
+          # Match the existing version badge regardless of style suffix,
+          # replacing only the version segment while preserving the rest.
+          pattern = re.compile(
+              r'(https://img\.shields\.io/badge/version-)[^-]+(-5fcfdd\?style=[a-z-]+)'
+          )
+          new_content, n = pattern.subn(
+              rf'\g<1>{version}\g<2>', content
+          )
+
+          if n == 0:
+              print("No version badge found to update (regex did not match).")
+              sys.exit(1)
+
+          if new_content == content:
+              print(f"Badge already at version {version}, nothing to do.")
+              sys.exit(0)
+
+          with open('README.md', 'w') as f:
+              f.write(new_content)
+          print(f"Updated README version badge to {version} ({n} replacement(s)).")
+          PY
+
+      - name: Commit and push changes
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if git diff --quiet; then
+            echo "No changes to commit (badge already up to date)."
+          else
+            git add README.md
+            git commit -m "ci: update version badge to ${VERSION}"
+            git push origin main
+          fi

--- a/.github/workflows/update-version-badge.yml
+++ b/.github/workflows/update-version-badge.yml
@@ -1,7 +1,12 @@
 name: Update Version Badge
 
+# Runs on pull requests targeting main. When a PR changes pyproject.toml,
+# this reads the new version and updates the README badge on the PR branch
+# itself (PR branches are not branch-protected, so the bot can push back).
+# When the PR merges, pyproject.toml and README.md land together and the
+# badge is already in sync — no post-merge push to main required.
 on:
-  push:
+  pull_request:
     branches:
       - main
     paths:
@@ -16,8 +21,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          # Need full history to diff, and a token that can push back.
-          fetch-depth: 0
+          # Checkout the PR head so we push back to the PR branch.
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract version from pyproject.toml
@@ -68,7 +74,7 @@ jobs:
           print(f"Updated README version badge to {version} ({n} replacement(s)).")
           PY
 
-      - name: Commit and push changes
+      - name: Commit and push to PR branch
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
@@ -80,5 +86,5 @@ jobs:
           else
             git add README.md
             git commit -m "ci: update version badge to ${VERSION}"
-            git push origin main
+            git push
           fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,34 +34,6 @@ repos:
         # Skip test files (less critical for security)
         exclude: ^tests/
 
-  # Sync README version badge with pyproject.toml version on every version bump
-  - repo: local
-    hooks:
-      - id: update-version-badge
-        name: Update README version badge
-        entry: python3
-        language: system
-        files: '^pyproject\.toml$'
-        pass_filenames: false
-        args:
-          - -c
-          - |
-            import tomllib, re, subprocess
-            with open('pyproject.toml', 'rb') as f:
-                version = tomllib.load(f)['tool']['poetry']['version']
-            with open('README.md', 'r') as f:
-                content = f.read()
-            new_content = re.sub(
-                r'(https://img\.shields\.io/badge/version-)[^-]+(-5fcfdd\?style=[a-z-]+)',
-                rf'\g<1>{version}\g<2>',
-                content
-            )
-            if new_content != content:
-                with open('README.md', 'w') as f:
-                    f.write(new_content)
-                subprocess.run(['git', 'add', 'README.md'])
-                print(f'Updated README version badge to {version}')
-
   # Check for hardcoded passwords in Python test files (only in new commits)
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,14 +8,14 @@ repos:
   - repo: https://github.com/GitGuardian/ggshield
     rev: v1.43.0
     hooks:
-        - id: ggshield
-          name: ggshield secret scan (pre-commit)
-          args: ["secret", "scan", "pre-commit", "--verbose"]
-          stages: [pre-commit]
-        - id: ggshield
-          name: ggshield secret scan (pre-push)
-          args: ["secret", "scan", "pre-push", "--verbose"]
-          stages: [pre-push]
+      - id: ggshield
+        name: ggshield secret scan (pre-commit)
+        args: ["secret", "scan", "pre-commit", "--verbose"]
+        stages: [pre-commit]
+      - id: ggshield
+        name: ggshield secret scan (pre-push)
+        args: ["secret", "scan", "pre-push", "--verbose"]
+        stages: [pre-push]
 
   # Semgrep - catches security issues similar to CodeQL (XSS, injection, etc.)
   - repo: https://github.com/semgrep/semgrep
@@ -52,8 +52,8 @@ repos:
             with open('README.md', 'r') as f:
                 content = f.read()
             new_content = re.sub(
-                r'https://img\.shields\.io/badge/version-[^-]+-5fcfdd\?style=for-the-badge',
-                f'https://img.shields.io/badge/version-{version}-5fcfdd?style=for-the-badge',
+                r'(https://img\.shields\.io/badge/version-)[^-]+(-5fcfdd\?style=[a-z-]+)',
+                rf'\g<1>{version}\g<2>',
                 content
             )
             if new_content != content:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
  <a href="https://github.com/eatyourpeas/checktick/releases">
-  <img alt="Version" src="https://img.shields.io/badge/version-0.4.6-5fcfdd?style=flat-square">
+  <img alt="Version" src="https://img.shields.io/badge/version-0.6.5-5fcfdd?style=flat-square">
  </a>
  <a href="https://github.com/eatyourpeas/checktick/blob/main/LICENSE">
   <img alt="GitHub License" src="https://img.shields.io/github/license/eatyourpeas/checktick?style=flat-square&color=5fcfdd">


### PR DESCRIPTION
Version drift occured between the readme badge and pyproject.toml because of an error in the githook. Reverted to a github action step triggering on version change when raising pr to main