### PR TITLE
fix/oidc-personal-ms-accounts

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,7 @@ body:
       value: |
         Thanks for taking the time to report a bug! Please search existing issues first to avoid duplicates.
 
-        **Note**: If you're using the hosted version at https://checktick.eatyourpeas.dev and dealing with sensitive data, please ensure you don't include any patient information or real survey data in this report.
+        **Note**: If you're using the hosted version at https://checktick.uk and dealing with sensitive data, please ensure you don't include any patient information or real survey data in this report.
 
   - type: dropdown
     id: deployment-type
@@ -16,7 +16,7 @@ body:
       label: Deployment Type
       description: Are you using the hosted version or self-hosting?
       options:
-        - Hosted version (checktick.eatyourpeas.dev)
+        - Hosted version (checktick.uk)
         - Self-hosted (Docker)
         - Self-hosted (other)
         - Local development

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -13,5 +13,5 @@ contact_links:
     url: https://github.com/eatyourpeas/checktick/tree/main/docs
     about: Browse the complete documentation
   - name: 🌐 Hosted Demo
-    url: https://checktick.eatyourpeas.dev
+    url: https://checktick.uk
     about: Try CheckTick online (demo environment)

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -66,7 +66,7 @@ body:
       label: Deployment Context
       description: How are you using CheckTick?
       options:
-        - Hosted version (checktick.eatyourpeas.dev)
+        - Hosted version (checktick.uk)
         - Self-hosted (production)
         - Self-hosted (development/testing)
         - Local development
@@ -161,6 +161,6 @@ body:
         - 📚 **Documentation**: Check the `/docs` folder for detailed guides
         - 🔍 **Search**: Look through existing issues and discussions
         - 💬 **Community**: Engage with other users in discussions
-        - 🚀 **Hosted Service**: For hosted service support, mention you're using checktick.eatyourpeas.dev
+        - 🚀 **Hosted Service**: For hosted service support, mention you're using checktick.uk
 
         We'll do our best to help you succeed with CheckTick!

--- a/.github/ISSUE_TEMPLATE/question_group_template_request.yml
+++ b/.github/ISSUE_TEMPLATE/question_group_template_request.yml
@@ -11,7 +11,7 @@ body:
         CheckTick maintains a collection of validated, reusable Question Group Templates (such as PHQ-9, GAD-7, etc.) that are available to all users. These templates help users quickly add standardised questionnaires to their surveys.
 
         Before requesting a new template, please:
-        1. Check the [existing templates](https://checktick.eatyourpeas.com/templates/) to see if it already exists
+        1. Check the [existing templates](https://checktick.uk/templates/) to see if it already exists
         2. Search existing issues to avoid duplicates
         3. Ensure this is a validated, published questionnaire (not a custom/draft instrument)
         4. Verify you have permission to share this questionnaire (check licensing/copyright)
@@ -132,7 +132,7 @@ body:
     id: template-content
     attributes:
       label: Template Content
-      description: Provide the questions in markdown format (see [documentation](https://checktick.eatyourpeas.com/docs/import/))
+      description: Provide the questions in markdown format (see [documentation](https://checktick.uk/docs/import/))
       placeholder: |
         # Template Name {template-id}
 
@@ -282,4 +282,4 @@ body:
         2. Publish it at organisation level (if you're in an organisation)
         3. Once reviewed and approved, we can promote it to global level
 
-        **For more information**, see the [Question Group Template documentation](https://checktick.eatyourpeas.com/docs/publish-question-groups/).
+        **For more information**, see the [Question Group Template documentation](https://checktick.uk/docs/publish-question-groups/).

--- a/.github/workflows/update-version-badge.yml
+++ b/.github/workflows/update-version-badge.yml
@@ -36,10 +36,7 @@ jobs:
           print(data['tool']['poetry']['version'])
           PY
           )
-          {
-            echo "version=$VERSION"
-            echo "Version: $VERSION"
-          } >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Update README badge
         env:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ docker compose -f docker-compose.registry.yml up -d
 
 **Docker Images:** [ghcr.io/eatyourpeas/checktick](https://github.com/eatyourpeas/checktick/pkgs/container/checktick)
 
-**Full Documentation:** See [Self-Hosting Guides](https://checktick.eatyourpeas.dev/docs/self-hosting-quickstart/)
+**Full Documentation:** See [Self-Hosting Guides](https://checktick.uk/docs/self-hosting-quickstart/)
 
 ## Versioning & Deployment
 
@@ -82,7 +82,7 @@ For release, container tags, and publish trigger rules, see [docs/versioning-and
 
 - **[Discussions](https://github.com/eatyourpeas/checktick/discussions)** - For questions, ideas, and community support
 - **[Issues](https://github.com/eatyourpeas/checktick/issues)** - For bug reports and specific feature requests
-- **[Documentation](https://checktick.eatyourpeas.dev/docs/)** - Complete guides and API documentation
+- **[Documentation](https://checktick.uk/docs/)** - Complete guides and API documentation
 
 ### When to use what?
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
  <a href="https://github.com/eatyourpeas/checktick/releases">
-  <img alt="Version" src="https://img.shields.io/badge/version-0.6.5-5fcfdd?style=flat-square">
+  <img alt="Version" src="https://img.shields.io/badge/version-0.7.1-5fcfdd?style=flat-square">
  </a>
  <a href="https://github.com/eatyourpeas/checktick/blob/main/LICENSE">
   <img alt="GitHub License" src="https://img.shields.io/github/license/eatyourpeas/checktick?style=flat-square&color=5fcfdd">

--- a/checktick_app/core/oidc_views.py
+++ b/checktick_app/core/oidc_views.py
@@ -62,12 +62,8 @@ class HealthcareOIDCCallbackView(OIDCAuthenticationCallbackView):
                 # Set Azure values
                 settings.OIDC_RP_CLIENT_ID = settings.OIDC_RP_CLIENT_ID_AZURE
                 settings.OIDC_RP_CLIENT_SECRET = settings.OIDC_RP_CLIENT_SECRET_AZURE
-                settings.OIDC_OP_TOKEN_ENDPOINT = (
-                    "https://login.microsoftonline.com/common/oauth2/v2.0/token"
-                )
-                settings.OIDC_OP_USER_ENDPOINT = (
-                    "https://graph.microsoft.com/oidc/userinfo"
-                )
+                settings.OIDC_OP_TOKEN_ENDPOINT = settings.OIDC_OP_TOKEN_ENDPOINT_AZURE
+                settings.OIDC_OP_USER_ENDPOINT = settings.OIDC_OP_USER_ENDPOINT_AZURE
                 settings.OIDC_OP_JWKS_ENDPOINT = settings.OIDC_OP_JWKS_ENDPOINT_AZURE
                 settings.OIDC_RP_SCOPES = "openid email profile"
 
@@ -254,16 +250,12 @@ class HealthcareOIDCAuthView(OIDCAuthenticationRequestView):
         # Set the attributes that the parent class reads directly
         self.OIDC_RP_CLIENT_ID = settings.OIDC_RP_CLIENT_ID_AZURE
         self.OIDC_RP_CLIENT_SECRET = settings.OIDC_RP_CLIENT_SECRET_AZURE
-        self.OIDC_OP_AUTH_ENDPOINT = (
-            "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
-        )
+        self.OIDC_OP_AUTH_ENDPOINT = settings.OIDC_OP_AUTHORIZATION_ENDPOINT_AZURE
         self.OIDC_OP_AUTHORIZATION_ENDPOINT = (
-            "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+            settings.OIDC_OP_AUTHORIZATION_ENDPOINT_AZURE
         )
-        self.OIDC_OP_TOKEN_ENDPOINT = (
-            "https://login.microsoftonline.com/common/oauth2/v2.0/token"
-        )
-        self.OIDC_OP_USER_ENDPOINT = "https://graph.microsoft.com/oidc/userinfo"
+        self.OIDC_OP_TOKEN_ENDPOINT = settings.OIDC_OP_TOKEN_ENDPOINT_AZURE
+        self.OIDC_OP_USER_ENDPOINT = settings.OIDC_OP_USER_ENDPOINT_AZURE
         self.OIDC_OP_JWKS_ENDPOINT = settings.OIDC_OP_JWKS_ENDPOINT_AZURE
         # Use only OIDC protocol scopes - no Graph API permissions needed
         self.OIDC_RP_SCOPES = "openid email profile"

--- a/checktick_app/settings.py
+++ b/checktick_app/settings.py
@@ -1,9 +1,9 @@
 import os
-import sys
 from pathlib import Path
+import sys
 
-import environ
 from csp.constants import NONCE as CSP_NONCE
+import environ
 
 # Detect if running tests
 TESTING = "pytest" in sys.modules or "test" in sys.argv

--- a/checktick_app/settings.py
+++ b/checktick_app/settings.py
@@ -1,9 +1,9 @@
 import os
-from pathlib import Path
 import sys
+from pathlib import Path
 
-from csp.constants import NONCE as CSP_NONCE
 import environ
+from csp.constants import NONCE as CSP_NONCE
 
 # Detect if running tests
 TESTING = "pytest" in sys.modules or "test" in sys.argv
@@ -586,7 +586,7 @@ else:
 # Email configuration
 ADMINS = [
     # Add your admin email(s) here as tuples of (name, email)
-    # Example: ADMINS = [("DevOps Team", "devops@eatyourpeas.dev")]
+    # Example: ADMINS = [("DevOps Team", "devops@checktick.uk")]
     ("DevOps Team", CTO_EMAIL),
 ]
 DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL", default="no-reply@example.com")
@@ -817,7 +817,26 @@ if DEBUG:
     OIDC_BASE_URL = "http://localhost:8000"
 else:
     # Production
-    OIDC_BASE_URL = "https://checktick.eatyourpeas.dev"
+    OIDC_BASE_URL = "https://checktick.uk"
+
+# Azure OIDC endpoints are tenant-aware. ``/common/`` works for multitenant
+# org+personal audiences, but using the configured tenant ID makes the
+# audience explicit and avoids ambiguity when the app is single-tenant.
+# Fall back to ``common`` if no tenant ID is configured.
+_AZURE_TENANT = OIDC_OP_TENANT_ID_AZURE or "common"
+OIDC_OP_AUTHORIZATION_ENDPOINT_AZURE = (
+    f"https://login.microsoftonline.com/{_AZURE_TENANT}/oauth2/v2.0/authorize"
+)
+OIDC_OP_TOKEN_ENDPOINT_AZURE = (
+    f"https://login.microsoftonline.com/{_AZURE_TENANT}/oauth2/v2.0/token"
+)
+OIDC_OP_USER_ENDPOINT_AZURE = "https://graph.microsoft.com/oidc/userinfo"
+# JWKS endpoint is left configurable via env (defaults to common discovery)
+# so it can be overridden for sovereign clouds or single-tenant deployments.
+if not OIDC_OP_JWKS_ENDPOINT_AZURE:
+    OIDC_OP_JWKS_ENDPOINT_AZURE = (
+        f"https://login.microsoftonline.com/{_AZURE_TENANT}/discovery/v2.0/keys"
+    )
 
 # OIDC Provider Configuration
 OIDC_PROVIDERS = {
@@ -833,9 +852,9 @@ OIDC_PROVIDERS = {
     "azure": {
         "OIDC_RP_CLIENT_ID": OIDC_RP_CLIENT_ID_AZURE,
         "OIDC_RP_CLIENT_SECRET": OIDC_RP_CLIENT_SECRET_AZURE,
-        "OIDC_OP_AUTHORIZATION_ENDPOINT": "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
-        "OIDC_OP_TOKEN_ENDPOINT": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
-        "OIDC_OP_USER_ENDPOINT": "https://graph.microsoft.com/oidc/userinfo",
+        "OIDC_OP_AUTHORIZATION_ENDPOINT": OIDC_OP_AUTHORIZATION_ENDPOINT_AZURE,
+        "OIDC_OP_TOKEN_ENDPOINT": OIDC_OP_TOKEN_ENDPOINT_AZURE,
+        "OIDC_OP_USER_ENDPOINT": OIDC_OP_USER_ENDPOINT_AZURE,
         "OIDC_OP_JWKS_ENDPOINT": OIDC_OP_JWKS_ENDPOINT_AZURE,
         "OIDC_RP_SCOPES": "openid email profile",
     },

--- a/docs/getting-help.md
+++ b/docs/getting-help.md
@@ -160,7 +160,7 @@ Maintainers can help with this conversion process.
 
 1. **Search first**: Check existing discussions, issues, and documentation
 2. **Check the docs**: Browse `/docs` folder and the live documentation
-3. **Try the demo**: Test functionality at <https://checktick.eatyourpeas.dev>
+3. **Try the demo**: Test functionality at <https://checktick.uk>
 4. **Gather information**: Have your environment details ready
 
 ### When Posting
@@ -193,8 +193,8 @@ When asking questions or reporting issues:
 
 ## Need More Help?
 
-- **Documentation**: <https://checktick.eatyourpeas.dev/docs/>
-- **Demo Environment**: <https://checktick.eatyourpeas.dev>
+- **Documentation**: <https://checktick.uk/docs/>
+- **Demo Environment**: <https://checktick.uk>
 - **Discussions**: <https://github.com/eatyourpeas/checktick/discussions>
 - **Issues**: <https://github.com/eatyourpeas/checktick/issues>
 - **Security**: <https://github.com/eatyourpeas/checktick/security/advisories/new>

--- a/docs/oidc-sso-setup.md
+++ b/docs/oidc-sso-setup.md
@@ -52,18 +52,26 @@ OIDC_OP_JWKS_ENDPOINT_AZURE=https://login.microsoftonline.com/common/discovery/v
 3. Click **New registration**
 4. Configure:
    - **Name**: `CheckTick Healthcare Platform`
-   - **Supported account types**:
-     - **Multitenant**: "Accounts in any organisational directory" (for multiple hospitals)
-     - **Single tenant**: "Accounts in this organisational directory only" (for single organisation)
+   - **Supported account types**: **Accounts in any organizational directory and personal Microsoft accounts**
+     - This is the recommended audience for CheckTick. It allows clinicians to sign in with personal Microsoft accounts (e.g. `outlook.com`, `hotmail.com`) today, and is also ready for future organizational SSO (e.g. NHS Login, hospital M365 tenants) without re-registering the app.
+     - Other options:
+       - **Accounts in this organizational directory only** (single tenant): use only if all clinicians belong to one Entra ID tenant. The configured `OIDC_OP_TENANT_ID_AZURE` will be used in endpoint URLs.
+       - **Accounts in any organizational directory** (multitenant org): work/school accounts only; personal Microsoft accounts will be rejected with `unauthorized_client`.
+       - **Personal Microsoft accounts only**: consumers only; no organizational SSO.
    - **Redirect URI**:
-     - **Type**: Web
+     - **Type**: Web (not SPA — CheckTick is a confidential client that stores a client secret server-side)
      - **URL**: `https://your-checktick-domain.com/oidc/callback/`
      - **Development**: Also add `http://localhost:8000/oidc/callback/`
+
+> **Important — audience changes are not editable on an existing registration.**
+> Azure does not allow changing `signInAudience` via the Manifest editor after creation (you will see `invalid specified value for property signInAudience` or `Property api.requestedAccessTokenVersion is invalid`). To switch audiences, create a **new** app registration with the desired account type selected at creation time. Azure automatically sets `requestedAccessTokenVersion: 1` for the personal+org audience — no manifest editing is required.
+>
+> **Token version note:** The personal+org audience requires access token version 1. This only affects the format of access tokens sent to Graph; the OIDC ID tokens that `mozilla-django-oidc` validates are still v2.0 RS256 and are validated against the v2.0 discovery/keys endpoints. No code changes are required.
 
 ### Step 2: Configure Application Settings
 
 1. **Authentication** tab:
-   - Under **Redirect URIs**, ensure your callback URLs are listed
+   - Under **Redirect URIs**, ensure your callback URLs are listed (platform type **Web**)
    - **Front-channel logout URL**: `https://your-checktick-domain.com/accounts/logout/`
    - **Implicit grant and hybrid flows**: Leave unchecked (CheckTick uses authorization code flow)
 
@@ -74,12 +82,13 @@ OIDC_OP_JWKS_ENDPOINT_AZURE=https://login.microsoftonline.com/common/discovery/v
    - **Copy the secret value** (this is your `OIDC_RP_CLIENT_SECRET_AZURE`)
 
 3. **API permissions** tab:
-   - Ensure these permissions are present:
+   - Ensure these delegated permissions are present:
      - `openid` (OpenID Connect sign-in)
      - `profile` (View users' basic profile)
      - `email` (View users' email address)
      - `User.Read` (Read user profiles)
    - Click **Grant admin consent** if you have admin rights
+   - These permissions work for both personal and organizational accounts
 
 ### Step 3: Note Configuration Values
 
@@ -87,6 +96,8 @@ From the **Overview** tab, copy:
 
 - **Application (client) ID** → `OIDC_RP_CLIENT_ID_AZURE`
 - **Directory (tenant) ID** → `OIDC_OP_TENANT_ID_AZURE`
+
+> **Tenant ID usage:** CheckTick uses `OIDC_OP_TENANT_ID_AZURE` to build the Azure authorize/token/JWKS endpoint URLs. For the recommended personal+org audience, the tenant placeholder `/common/` is used at runtime (the configured tenant ID is still required for documentation and for future single-tenant deployments). If `OIDC_OP_TENANT_ID_AZURE` is empty, CheckTick falls back to `/common/`.
 
 ### Step 4: Configure External User Access (Optional)
 
@@ -314,11 +325,18 @@ OIDC Key = PBKDF2(
    - Verify client ID and secret in environment variables
    - Check for extra spaces or quotes
 
-3. **"Access denied"**:
+3. **"unauthorized_client: The client does not exist or is not enabled for consumers"**:
+   - The app registration's supported account types do not include personal Microsoft accounts, but the user is signing in with a personal account (`outlook.com`, `hotmail.com`, etc.).
+   - Fix: create a new app registration with **Accounts in any organizational directory and personal Microsoft accounts** (see Step 1). This audience cannot be enabled on an existing org-only registration via the Manifest editor.
+
+4. **"invalid specified value for property signInAudience"** or **"Property api.requestedAccessTokenVersion is invalid"** when saving the manifest:
+   - Azure does not allow changing `signInAudience` on an existing registration. Create a new registration with the desired audience selected at creation time instead.
+
+5. **"Access denied"**:
    - Verify API permissions in Azure AD
    - Check OAuth consent screen configuration in Google
 
-4. **"Email not found"**:
+6. **"Email not found"**:
    - Ensure `email` scope is requested
    - For Azure: verify `User.Read` permission
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "checktick"
-version = "0.7.0"
+version = "0.7.1"
 description = "Secure, server-rendered survey platform for medical audit and research"
 authors = ["CheckTick Maintainers <simon@eatyourpeas.co.uk>"]
 readme = "README.md"


### PR DESCRIPTION
fix(oidc): enable personal Microsoft accounts and wire tenant ID into Azure endpoints

The Azure app registration was configured for org-only accounts, so
personal Microsoft accounts (outlook.com, hotmail.com) were rejected
with `unauthorized_client: ... not enabled for consumers`. The
`OIDC_OP_TENANT_ID_AZURE` setting was also collected from env but
never used — all Azure endpoints were hardcoded to `/common/`.

- settings.py: derive Azure authorize/token/JWKS endpoints from
  `OIDC_OP_TENANT_ID_AZURE` (falls back to `common` when empty), and
  fix stale `OIDC_BASE_URL` (checktick.eatyourpeas.dev → checktick.uk).
- oidc_views.py: read Azure endpoints from the new derived settings in
  both the auth and callback views instead of hardcoded `/common/`.
- docs/oidc-sso-setup.md: recommend "any org + personal Microsoft
  accounts" as the audience, document that signInAudience cannot be
  changed on an existing registration, and add troubleshooting entries
  for the unauthorized_client and manifest-save errors.
- Replace remaining checktick.eatyourpeas.dev / .com references with
  checktick.uk across README, getting-help.md, and issue templates.

No code changes are required for the personal+org audience itself; v1
access tokens only affect Graph access-token format, not the v2.0
RS256 ID tokens that mozilla-django-oidc validates.
