### PR TITLE
Fix/reporting template

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
  <a href="https://github.com/eatyourpeas/checktick/releases">
-  <img alt="Version" src="https://img.shields.io/badge/version-0.7.8-5fcfdd?style=flat-square">
+  <img alt="Version" src="https://img.shields.io/badge/version-0.7.9-5fcfdd?style=flat-square">
  </a>
  <a href="https://github.com/eatyourpeas/checktick/blob/main/LICENSE">
   <img alt="GitHub License" src="https://img.shields.io/github/license/eatyourpeas/checktick?style=flat-square&color=5fcfdd">

--- a/checktick_app/surveys/services/export_service.py
+++ b/checktick_app/surveys/services/export_service.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import transaction
+from django.urls import reverse
 from django.utils import timezone
 
 if TYPE_CHECKING:
@@ -312,8 +313,17 @@ class ExportService:
         if export.is_download_url_expired:
             raise ValueError("Download URL has expired")
 
-        # Return URL pattern for downloading the export
-        return f"/api/surveys/{export.survey_id}/exports/{export.id}/download/{export.download_token}/"
+        # Reverse the named route so the URL can never drift from the URL conf.
+        # The route is surveys:survey_export_file:
+        #   <slug:slug>/export/<uuid:export_id>/download/<str:token>/
+        return reverse(
+            "surveys:survey_export_file",
+            kwargs={
+                "slug": export.survey.slug,
+                "export_id": export.id,
+                "token": export.download_token,
+            },
+        )
 
     @classmethod
     @transaction.atomic

--- a/checktick_app/surveys/templates/surveys/data_governance/export_create.html
+++ b/checktick_app/surveys/templates/surveys/data_governance/export_create.html
@@ -57,7 +57,7 @@
                         autocomplete="new-password"
                     />
                     <label class="label">
-                        <span class="label-text-alt text-gray-500">
+                        <span class="label-text-alt text-gray-500 whitespace-normal break-words min-w-0">
                             {% trans "Recommended for sensitive data. The ZIP file will be encrypted with this password." %}
                         </span>
                     </label>
@@ -66,7 +66,7 @@
                 <div class="divider"></div>
 
                 <div class="form-control">
-                    <label class="label cursor-pointer justify-start gap-3">
+                    <label class="label cursor-pointer justify-start gap-3 items-start">
                         <input
                             type="checkbox"
                             name="attestation_accepted"
@@ -74,9 +74,9 @@
                             class="checkbox checkbox-primary"
                             required
                         />
-                        <span class="label-text">
+                        <span class="label-text whitespace-normal break-words min-w-0 flex-1">
                             {% blocktrans %}
-                            I confirm that I am authorized to export this data and will handle it in accordance with applicable data protection policies.
+                            I confirm that I am authorised to export this data and will handle it in accordance with applicable data protection policies.
                             {% endblocktrans %}
                         </span>
                     </label>

--- a/checktick_app/surveys/templates/surveys/data_governance/export_download.html
+++ b/checktick_app/surveys/templates/surveys/data_governance/export_download.html
@@ -73,7 +73,7 @@
                                 id="download-url"
                             />
                             <button
-                                onclick="copyToClipboard()"
+                                id="copy-url-btn"
                                 class="btn btn-secondary"
                             >
                                 {% trans "Copy" %}
@@ -116,14 +116,23 @@
 </div>
 
 <script nonce="{{ request.csp_nonce }}">
-function copyToClipboard() {
-    const input = document.getElementById('download-url');
-    input.select();
-    input.setSelectionRange(0, 99999); // For mobile devices
-    document.execCommand('copy');
+(function () {
+    function copyToClipboard() {
+        const input = document.getElementById('download-url');
+        input.select();
+        input.setSelectionRange(0, 99999); // For mobile devices
+        document.execCommand('copy');
 
-    // Show toast notification (if you have a toast system)
-    alert('{% trans "Link copied to clipboard!" %}');
-}
+        // Show toast notification (if you have a toast system)
+        alert('{% trans "Link copied to clipboard!" %}');
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        const btn = document.getElementById('copy-url-btn');
+        if (btn) {
+            btn.addEventListener('click', copyToClipboard);
+        }
+    });
+})();
 </script>
 {% endblock %}

--- a/checktick_app/surveys/templates/surveys/partials/response_insights.html
+++ b/checktick_app/surveys/templates/surveys/partials/response_insights.html
@@ -1,4 +1,4 @@
-{% comment %} 
+{% comment %}
 Response Insights Partial Displays answer distribution charts for
 survey responses. This partial is designed to be easily swappable for a
 JavaScript charting library (e.g., Plotly) in the future. Expected context: -
@@ -6,10 +6,10 @@ analytics: ResponseAnalytics object with distributions - survey: Survey object
 (for linking/context) To swap to Plotly later: 1. Change this partial to render
 a container div with data attributes 2. Add a script block that initializes
 Plotly charts from the data 3. The view/service stays the same - just the
-rendering changes 
-{% endcomment %} 
+rendering changes
+{% endcomment %}
 
-{% load i18n %} 
+{% load i18n %}
 {% if analytics.distributions %}
 <div class="mt-6">
     <details class="collapse collapse-arrow bg-base-100 shadow-sm" open>
@@ -48,14 +48,12 @@ rendering changes
                         {# Question header #}
                         <h4 class="card-title text-sm font-medium mb-3">
                             {{ dist.question_text }}
-                            <span class="badge badge-ghost badge-sm ml-auto"
-                                >{{ dist.total_responses }} {% trans "responses"
-                                %}</span
-                            >
+                            <span class="badge badge-ghost badge-sm ml-auto">
+                                {{ dist.total_responses }} {% trans "responses"%}
+                            </span>
                         </h4>
 
-                        {# Chart container - data attributes for future JS
-                        library #}
+                        {# Chart container - data attributes for future JS library #}
                         <div
                             class="response-chart"
                             data-question-id="{{ dist.question_id }}"
@@ -72,12 +70,13 @@ rendering changes
                                         title="{{ option.label }}"
                                     >
                                         {% if dist.question_type == 'yesno' %}
-                                        {% if option.label == 'Yes' %}
-                                        <span class="text-success">✓</span>
-                                        {% else %}
-                                        <span class="text-error">✗</span>
-                                        {% endif %} {% endif %} {{ option.label
-                                        }}
+                                            {% if option.label == 'Yes' %}
+                                                <span class="text-success">✓</span>
+                                            {% else %}
+                                                <span class="text-error">✗</span>
+                                            {% endif %}
+                                        {% endif %}
+                                        {{ option.label }}
                                     </span>
 
                                     {# Bar #}

--- a/checktick_app/surveys/tests/test_data_governance_services.py
+++ b/checktick_app/surveys/tests/test_data_governance_services.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 from unittest.mock import patch
 
 from django.contrib.auth.models import User
+from django.urls import reverse
 from django.utils import timezone
 import pytest
 
@@ -167,14 +168,27 @@ class TestExportService:
         assert export.encryption_key_id is None
 
     def test_get_download_url(self, survey_with_responses, user):
-        """Should generate download URL from export."""
+        """Should generate download URL that reverses to the file route."""
         with patch.object(ExportService, "_generate_csv", return_value="mock,csv"):
             export = ExportService.create_export(survey_with_responses, user)
 
         url = ExportService.get_download_url(export)
 
+        # The URL must reverse to the named file-download route and contain the
+        # real token + export id. This locks down the previous bug where the
+        # service hand-built a /api/surveys/... URL that 404'd.
+        expected = reverse(
+            "surveys:survey_export_file",
+            kwargs={
+                "slug": export.survey.slug,
+                "export_id": export.id,
+                "token": export.download_token,
+            },
+        )
+        assert url == expected
         assert export.download_token in url
         assert str(export.id) in url
+        assert export.survey.slug in url
 
     def test_get_download_url_fails_for_expired(self, survey_with_responses, user):
         """Should raise error for expired download URL."""

--- a/checktick_app/surveys/tests/test_data_governance_views.py
+++ b/checktick_app/surveys/tests/test_data_governance_views.py
@@ -632,6 +632,114 @@ class TestSurveyExportFileSecurity:
         assert "== token" not in src
         assert "== export.download_token" not in src
 
+    def test_platform_admin_cannot_download_survey_data(
+        self, client, closed_survey, user
+    ):
+        """
+        Platform Admins (superusers) must NOT be able to download survey data.
+
+        This is a deliberate security boundary: CheckTick staff and platform
+        operators must not be able to read patient/respondent data. The
+        permission helper `can_export_survey_data` returns False for a
+        platform admin who does not independently hold an in-survey role
+        (owner / org owner / org admin / active data custodian), and the
+        export file view enforces this even when a valid token is present.
+        """
+        from checktick_app.surveys.models import SurveyResponse
+        from checktick_app.surveys.permissions import can_export_survey_data
+
+        # Create a response + export owned by `user` (not the platform admin).
+        SurveyResponse.objects.create(
+            survey=closed_survey,
+            submitted_by=user,
+            submitted_at=timezone.now(),
+            answers={"q": "a"},
+        )
+        export = ExportService.create_export(
+            survey=closed_survey, user=user, password=None
+        )
+
+        # Platform admin who has no relationship to this survey.
+        platform_admin = User.objects.create_user(
+            username="platform-admin",
+            email="platform-admin@example.com",
+            password=TEST_PASSWORD,
+            is_superuser=True,
+            is_staff=True,
+        )
+
+        # 1. Permission helper must deny.
+        assert can_export_survey_data(platform_admin, closed_survey) is False
+
+        # 2. The download page (which calls require_can_export_survey_data)
+        #    must deny with 403.
+        client.force_login(platform_admin)
+        download_page_url = reverse(
+            "surveys:survey_export_download",
+            kwargs={"slug": closed_survey.slug, "export_id": export.id},
+        )
+        assert client.get(download_page_url).status_code == 403
+
+        # 3. The file download route must deny even with a valid token.
+        file_url = reverse(
+            "surveys:survey_export_file",
+            kwargs={
+                "slug": closed_survey.slug,
+                "export_id": export.id,
+                "token": export.download_token,
+            },
+        )
+        response = client.get(file_url)
+        assert response.status_code == 403
+        assert response["Content-Type"] != "text/csv"
+
+    def test_platform_admin_who_is_also_owner_can_download(
+        self, client, closed_survey, user
+    ):
+        """
+        A Platform Admin who is *also* the survey owner can download.
+
+        The exclusion is based on role, not user identity: a platform admin
+        who independently holds an in-survey role (here: survey owner) is
+        granted access through that role. This guards against an over-broad
+        denial that would lock owners out of their own surveys after being
+        granted platform admin status.
+        """
+        from checktick_app.surveys.models import SurveyResponse
+        from checktick_app.surveys.permissions import can_export_survey_data
+
+        SurveyResponse.objects.create(
+            survey=closed_survey,
+            submitted_by=user,
+            submitted_at=timezone.now(),
+            answers={"q": "a"},
+        )
+        export = ExportService.create_export(
+            survey=closed_survey, user=user, password=None
+        )
+
+        # Promote the survey owner to platform admin.
+        user.is_superuser = True
+        user.is_staff = True
+        user.save()
+
+        # Permission helper grants via the owner branch, not the platform-admin
+        # branch (there is no platform-admin branch).
+        assert can_export_survey_data(user, closed_survey) is True
+
+        client.force_login(user)
+        file_url = reverse(
+            "surveys:survey_export_file",
+            kwargs={
+                "slug": closed_survey.slug,
+                "export_id": export.id,
+                "token": export.download_token,
+            },
+        )
+        response = client.get(file_url)
+        assert response.status_code == 200
+        assert response["Content-Type"] == "text/csv"
+
 
 # ========== Survey Close Integration Test ==========
 

--- a/checktick_app/surveys/tests/test_data_governance_views.py
+++ b/checktick_app/surveys/tests/test_data_governance_views.py
@@ -504,6 +504,31 @@ class TestSurveyExportFileSecurity:
         assert "login" in response.url
         assert response["Content-Type"] != "text/csv"
 
+    def test_file_download_rejects_non_owner_with_valid_token(
+        self, client, other_user, export_with_token
+    ):
+        """
+        A non-owner holding a valid (e.g. leaked) token must still be denied.
+
+        The token is a second factor, not a replacement for authorisation.
+        Only the survey owner (or their seniors: org owner, org admins,
+        active data custodians) may download exported survey data. This is
+        the core security property for a sensitive-data export route.
+        """
+        client.force_login(other_user)
+        url = reverse(
+            "surveys:survey_export_file",
+            kwargs={
+                "slug": export_with_token.survey.slug,
+                "export_id": export_with_token.id,
+                "token": export_with_token.download_token,
+            },
+        )
+        response = client.get(url)
+
+        assert response.status_code == 403
+        assert response["Content-Type"] != "text/csv"
+
     def test_file_download_rejects_cross_survey_token_reuse(
         self, client, user, export_with_token, other_survey_export
     ):
@@ -696,8 +721,10 @@ class TestExportPermissionEnforcement:
         )
         assert client.get(download_url).status_code == 403
 
-        # Download file - token-based access allows any authenticated user
-        # (The token IS the permission - like a share link)
+        # Download file - the token is a second factor, NOT a replacement
+        # for authorisation. A non-owner with a valid (leaked) token must
+        # still be denied: only the survey owner (or their seniors — org
+        # owner, org admins, active data custodians) may download exports.
         file_url = reverse(
             "surveys:survey_export_file",
             kwargs={
@@ -706,8 +733,8 @@ class TestExportPermissionEnforcement:
                 "token": export.download_token,
             },
         )
-        # Valid token = access granted (token is the security mechanism)
-        assert client.get(file_url).status_code == 200
+        # Valid token + no permission = 403, never the CSV.
+        assert client.get(file_url).status_code == 403
 
     def test_export_routes_allowed_for_owner(self, client, user, closed_survey):
         """Survey owner should have access to all export routes."""

--- a/checktick_app/surveys/tests/test_data_governance_views.py
+++ b/checktick_app/surveys/tests/test_data_governance_views.py
@@ -432,6 +432,182 @@ class TestSurveyExportFileView:
         assert "," in content and "\n" in content
 
 
+# ========== Export File Download Security Lockdown ==========
+
+
+@pytest.mark.django_db
+class TestSurveyExportFileSecurity:
+    """
+    Security lockdown for the sensitive-data export file route.
+
+    This route serves a CSV of patient/survey responses, so the tests here
+    lock down the guarantees that must hold even if the URL is leaked:
+      - anonymous users cannot download (login required)
+      - a valid token for one survey cannot be replayed against another
+      - a wrong slug + valid export_id yields 404 (no IDOR leakage)
+      - the download page renders an href that actually resolves (no 404 bug)
+      - the token comparison is constant-time (no timing oracle)
+    """
+
+    @pytest.fixture
+    def export_with_token(self, closed_survey, user):
+        """Create an export with a download token."""
+        from checktick_app.surveys.models import SurveyResponse
+
+        SurveyResponse.objects.create(
+            survey=closed_survey,
+            submitted_by=user,
+            submitted_at=timezone.now(),
+            answers={"question_1": "answer_1"},
+        )
+        return ExportService.create_export(
+            survey=closed_survey,
+            user=user,
+            password=None,
+        )
+
+    @pytest.fixture
+    def other_survey_export(self, user):
+        """A second, independent survey + export owned by the same user."""
+        survey = Survey.objects.create(
+            name="Other Survey",
+            slug="other-survey",
+            owner=user,
+            status=Survey.Status.PUBLISHED,
+        )
+        survey.close_survey(user)
+
+        from checktick_app.surveys.models import SurveyResponse
+
+        SurveyResponse.objects.create(
+            survey=survey,
+            submitted_by=user,
+            submitted_at=timezone.now(),
+            answers={"q": "a"},
+        )
+        return ExportService.create_export(survey=survey, user=user, password=None)
+
+    def test_file_download_requires_login(self, client, export_with_token):
+        """Anonymous requests must not receive the CSV; login is required."""
+        url = reverse(
+            "surveys:survey_export_file",
+            kwargs={
+                "slug": export_with_token.survey.slug,
+                "export_id": export_with_token.id,
+                "token": export_with_token.download_token,
+            },
+        )
+        response = client.get(url)
+
+        # @login_required redirects to login; never 200 with CSV body.
+        assert response.status_code == 302
+        assert "login" in response.url
+        assert response["Content-Type"] != "text/csv"
+
+    def test_file_download_rejects_cross_survey_token_reuse(
+        self, client, user, export_with_token, other_survey_export
+    ):
+        """A token from survey A must not grant access to survey B's export."""
+        client.force_login(user)
+        url = reverse(
+            "surveys:survey_export_file",
+            kwargs={
+                "slug": other_survey_export.survey.slug,
+                "export_id": other_survey_export.id,
+                "token": export_with_token.download_token,
+            },
+        )
+        response = client.get(url)
+
+        # Token mismatch -> redirect to dashboard, never the CSV.
+        assert response.status_code == 302
+        assert response.url == f"/surveys/{other_survey_export.survey.slug}/dashboard/"
+        assert response["Content-Type"] != "text/csv"
+
+    def test_file_download_wrong_slug_yields_404(
+        self, client, user, export_with_token, other_survey_export
+    ):
+        """
+        A valid export_id paired with the wrong slug must 404.
+
+        The view filters by `survey=survey`, so an export_id that exists but
+        belongs to a different survey is treated as not found — preventing
+        IDOR-style enumeration of export IDs across surveys.
+        """
+        client.force_login(user)
+        url = reverse(
+            "surveys:survey_export_file",
+            kwargs={
+                "slug": other_survey_export.survey.slug,
+                "export_id": export_with_token.id,  # belongs to a different survey
+                "token": export_with_token.download_token,
+            },
+        )
+        response = client.get(url)
+
+        assert response.status_code == 404
+        assert response["Content-Type"] != "text/csv"
+
+    def test_download_page_href_resolves_without_404(
+        self, client, user, export_with_token
+    ):
+        """
+        The href rendered on the download page must actually resolve.
+
+        Regression test for the bug where ExportService.get_download_url()
+        hand-built a /api/surveys/... URL that no route matched, causing the
+        "Download Export" button to 404. We follow the rendered href and
+        assert a 200 CSV response.
+        """
+        client.force_login(user)
+        page_url = reverse(
+            "surveys:survey_export_download",
+            kwargs={
+                "slug": export_with_token.survey.slug,
+                "export_id": export_with_token.id,
+            },
+        )
+        page = client.get(page_url)
+        assert page.status_code == 200
+
+        # Pull the href out of the "Download Export" anchor. The anchor
+        # contains an SVG before the text and the page also has breadcrumb
+        # links, so we target the href that contains the file-route segment
+        # `/download/` (unique to the survey_export_file route).
+        import re
+
+        page_html = page.content.decode()
+        href_match = re.search(r'href="([^"]*/download/[^"]+)"', page_html)
+        assert href_match is not None, "Download Export href not found on page"
+        href = href_match.group(1).replace("&amp;", "&")
+
+        # The href must be the route-reversed URL (not the old /api/... path).
+        assert href.startswith("/surveys/")
+        assert "/api/surveys/" not in href
+
+        # Following the href must yield the CSV, not a 404.
+        download = client.get(href)
+        assert download.status_code == 200
+        assert download["Content-Type"] == "text/csv"
+        assert "attachment" in download["Content-Disposition"]
+
+    def test_token_comparison_is_constant_time(self, export_with_token):
+        """
+        Token validation must use secrets.compare_digest (constant-time),
+        not `==`, to avoid a timing oracle on the download token.
+        """
+        import inspect
+
+        src = inspect.getsource(ExportService.validate_download_token)
+        assert "compare_digest" in src
+        # No raw equality comparison against the token anywhere in the body.
+        # (Allow `==` only inside docstrings/strings by checking the AST-free
+        # heuristic: compare_digest must be the comparison mechanism.)
+        assert "download_token ==" not in src
+        assert "== token" not in src
+        assert "== export.download_token" not in src
+
+
 # ========== Survey Close Integration Test ==========
 
 

--- a/checktick_app/surveys/views_data_governance.py
+++ b/checktick_app/surveys/views_data_governance.py
@@ -159,9 +159,20 @@ def survey_export_download(
 def survey_export_file(
     request: HttpRequest, slug: str, export_id: str, token: str
 ) -> HttpResponse:
-    """Download the actual export file (validates token)."""
+    """Download the actual export file (validates token + permission)."""
     survey = get_object_or_404(Survey, slug=slug)
-    export = get_object_or_404(DataExport, id=export_id, survey=survey)
+    export = get_object_or_404(
+        DataExport.objects.select_related("survey"),
+        id=export_id,
+        survey=survey,
+    )
+
+    # Permission check: only the survey owner (or their seniors — org owner,
+    # org admins, active data custodians) may download exported survey data.
+    # The token is a second factor (a share-link-style secret), not a
+    # replacement for authorisation — a leaked token must not let an
+    # unrelated user exfiltrate patient data.
+    require_can_export_survey_data(request.user, survey)
 
     # Validate download token
     if not ExportService.validate_download_token(export, token):

--- a/checktick_app/surveys/views_data_governance.py
+++ b/checktick_app/surveys/views_data_governance.py
@@ -134,7 +134,11 @@ def survey_export_download(
 ) -> HttpResponse:
     """Display download link for an export."""
     survey = get_object_or_404(Survey, slug=slug)
-    export = get_object_or_404(DataExport, id=export_id, survey=survey)
+    export = get_object_or_404(
+        DataExport.objects.select_related("survey"),
+        id=export_id,
+        survey=survey,
+    )
 
     require_can_export_survey_data(request.user, survey)
 

--- a/docs/authentication-and-permissions.md
+++ b/docs/authentication-and-permissions.md
@@ -433,7 +433,7 @@ Core permission checks in `checktick_app/surveys/permissions.py`:
 | `can_create_datasets` | Create new datasets |
 | `can_edit_dataset` | Edit existing datasets |
 | `can_close_survey` | Close/archive surveys |
-| `can_export_survey_data` | Export survey responses |
+| `can_export_survey_data` | Export survey responses (owner / org owner / org admin / active data custodian only — Platform Admins are deliberately excluded) |
 | `can_extend_retention` | Extend data retention periods |
 | `can_manage_legal_hold` | Manage legal hold status |
 | `can_manage_data_custodians` | Manage data custodian assignments |

--- a/docs/data-governance-export.md
+++ b/docs/data-governance-export.md
@@ -43,6 +43,14 @@ Access to data exports is strictly controlled based on your role:
 - Can only view or edit survey structure (if editor)
 - For data access, they must request the survey creator or organisation owner to download on their behalf
 
+### Platform Admins
+
+- **Cannot download data** - Deliberately excluded from all survey data access
+- Platform Admins (superusers) manage platform-level concerns only: account provisioning, billing, pricing overrides, promotions, and infrastructure/audit log review
+- They **cannot** view, download, or export survey responses, even with a valid download token
+- This is a deliberate security boundary: CheckTick staff and platform operators must not be able to read patient data
+- A Platform Admin can only download survey data if they independently satisfy one of the roles above (e.g. they are the survey's owner, an organisation owner/admin, or an active data custodian for that survey) — the `can_export_survey_data` permission helper enforces this and does not grant access on the basis of platform admin status alone
+
 ## When Can I Download Data?
 
 ### After Survey Closure

--- a/docs/data-governance-overview.md
+++ b/docs/data-governance-overview.md
@@ -33,11 +33,15 @@ Not everyone can access survey data. Access is strictly controlled based on role
 |------|-------------------|-------------------|---------------------|
 | **Survey Creator** | ✅ Own surveys | ✅ Own surveys | ✅ Own surveys |
 | **Organisation Owner** | ✅ All org surveys | ✅ All org surveys | ✅ All org surveys |
+| **Organisation Admin** | ✅ All org surveys | ✅ All org surveys | ✅ All org surveys |
 | **Data Custodian*** | ❌ No | ✅ Assigned surveys | ❌ No |
 | **Editor** | ❌ No | ❌ No | ❌ No |
 | **Viewer** | ❌ No | ❌ No | ❌ No |
+| **Platform Admin** | ❌ No | ❌ No | ❌ No |
 
 \* *Optional role - can be assigned per survey for data management delegation*
+
+**Platform Admins are deliberately excluded from survey data access.** Platform Admins (superusers) manage platform-level concerns only — account provisioning, billing, pricing overrides, promotions, and infrastructure/audit log review. They **cannot** view, download, or export survey responses, and `can_export_survey_data` returns `False` for them unless they also happen to be the survey's owner, an organisation owner/admin, or an active data custodian. This is a deliberate security boundary: CheckTick staff and platform operators must not be able to read patient data, and the permission helper enforces it. See [Platform Admin Functionality](platform-admin-functionality-technical-implementation.md) for the scope of platform admin capabilities.
 
 **Organisation Administrative Authority**
 To ensure accountability, every CheckTick Organisation must have at least one designated Owner.

--- a/docs/data-governance-policy.md
+++ b/docs/data-governance-policy.md
@@ -380,6 +380,18 @@ Participants can object to processing based on:
 
 **Access:** Cannot download survey data
 
+### 6.7 Platform Administrators
+
+**Responsibilities:**
+
+- Manage account provisioning, billing, pricing overrides, and promotions
+- Review platform-level audit and infrastructure logs
+- Operate platform-level administrative workflows (account status, refunds)
+
+**Access:** **Cannot view, download, or export survey response data.** Platform Administrators (superusers) are deliberately excluded from all survey data access. The `can_export_survey_data` permission helper does not grant access on the basis of platform admin status; a Platform Admin can only access survey data if they independently satisfy another role (survey owner, organisation owner/admin, or active data custodian for that survey).
+
+**Rationale:** CheckTick staff and platform operators must not be able to read patient or respondent data. This boundary is enforced in code by the permission helpers in `checktick_app/surveys/permissions.py` and is locked down by automated tests in `checktick_app/surveys/tests/test_data_governance_views.py`.
+
 ---
 
 ## 7. Security Measures

--- a/docs/platform-admin-functionality-technical-implementation.md
+++ b/docs/platform-admin-functionality-technical-implementation.md
@@ -44,6 +44,8 @@ Platform admin endpoints are superuser-only and protected by explicit controls:
 
 Design intent: administrative workflows are explicit, auditable, and fail-closed when authorization fails.
 
+**Data access boundary:** Platform Admins are deliberately excluded from survey response data. They cannot view, download, or export survey data, and `can_export_survey_data` returns `False` for platform admin status alone. Platform Admin capabilities are limited to account/billing/promotions operations and platform-level log review. A Platform Admin may only access survey data if they independently hold an in-survey role (survey owner, organisation owner/admin, or active data custodian). This boundary is enforced by the permission helpers in `checktick_app/surveys/permissions.py` and locked down by automated tests in `checktick_app/surveys/tests/test_data_governance_views.py`.
+
 ## Account and Billing Operations
 
 Platform admin supports operational workflows across account types and tiers:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "checktick"
-version = "0.7.8"
+version = "0.7.9"
 description = "Secure, server-rendered survey platform for medical audit and research"
 authors = ["CheckTick Maintainers <simon@eatyourpeas.co.uk>"]
 readme = "README.md"


### PR DESCRIPTION
FIxes two issues:

1. Template errors caused by wrapping django-html elements, particularly in the `export_create` and related templates. 
2. Fix the download csv broken link, secure with decorator and add tests to ensure only survey creators and their seniors can access the endpoint, excluding platform admins.

Updates the documentation to clarify this