### PR TITLE
Switch sct to upstream pacharanero/sct v0.20.1 and fix prod snomed.db update

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
  <a href="https://github.com/eatyourpeas/checktick/releases">
-  <img alt="Version" src="https://img.shields.io/badge/version-0.7.10-5fcfdd?style=flat-square">
+  <img alt="Version" src="https://img.shields.io/badge/version-0.7.11-5fcfdd?style=flat-square">
  </a>
  <a href="https://github.com/eatyourpeas/checktick/blob/main/LICENSE">
   <img alt="GitHub License" src="https://img.shields.io/github/license/eatyourpeas/checktick?style=flat-square&color=5fcfdd">

--- a/checktick_app/surveys/management/commands/update_snomed_db.py
+++ b/checktick_app/surveys/management/commands/update_snomed_db.py
@@ -3,7 +3,18 @@ Management command to check for and apply SNOMED CT database updates.
 
 Uses the `sct` binary's two-step approach:
   1. `sct trud check` — lightweight check against TRUD API (exit 0=current, 2=update, 1=error)
-  2. `sct trud download --pipeline` — download + build snomed.db only if needed
+  2. `sct trud download` (no --pipeline) + explicit `sct ndjson` + `sct sqlite`,
+     followed by an atomic `os.replace()` into the canonical snomed.db path.
+
+The pipeline is split deliberately rather than using `sct trud download --pipeline`:
+the pipeline mode writes SQLite directly to the canonical snomed.db path, which is
+held open read-only by gunicorn workers (SnomedResolver thread-local connections).
+`sct sqlite` then cannot get the exclusive lock it needs to clear and rebuild,
+failing with SQLITE_BUSY ("database is locked"). By building to a temp file on the
+same volume and `os.replace()`-ing it into place, the swap is atomic on POSIX and
+no exclusive lock is ever held against the live snomed.db. This makes the command
+safe to run while the web app is serving traffic, and therefore safe to run from a
+scheduled job.
 
 This avoids the cost of a full download when there is nothing new, making it
 safe to run frequently (e.g. as a daily cron / Northflank scheduled job).
@@ -228,7 +239,26 @@ class Command(BaseCommand):
                     self.stdout.write(check_result.stderr.strip())
                 sys.exit(1)
 
-        # ── Step 2: download + build pipeline ─────────────────────────────
+        # ── Step 2: download + build (explicit two-step, atomic swap) ─────
+        #
+        # We deliberately do NOT use `sct trud download --pipeline`. The
+        # pipeline mode chains ndjson + sqlite and writes the SQLite file
+        # directly to the canonical snomed.db path. That file is held open
+        # read-only by gunicorn workers (SnomedResolver thread-local
+        # connections), so `sct sqlite` cannot get the exclusive lock it
+        # needs to clear and rebuild — failing with SQLITE_BUSY ("database
+        # is locked").
+        #
+        # Instead we run the three steps ourselves:
+        #   1. `sct trud download`           — fetch + verify the RF2 zip
+        #   2. `sct ndjson --rf2 <zip>`      — build NDJSON to a temp path
+        #   3. `sct sqlite --ndjson <ndjson> --output <tmp>.db`
+        #                                    — build SQLite to a fresh file
+        #                                    nobody else has open
+        # Then atomically `os.replace(tmp_db, snomed.db)`. POSIX guarantees
+        # this is atomic: readers either keep their already-open fd on the
+        # old inode, or open the new inode on the next request. No exclusive
+        # lock is ever held against the live snomed.db.
         if needs_update:
             if force:
                 self.stdout.write(
@@ -242,19 +272,31 @@ class Command(BaseCommand):
                 f"   This may take several minutes (UK Monolith ~1.8 GB)."
             )
 
-            if dry_run:
-                self.stdout.write(
-                    f"   [DRY RUN] would run: sct trud download --edition {edition} "
-                    f"--pipeline --data-dir {data_dir}"
-                )
-                return
-
             # Redirect TMPDIR to the mounted volume so that sct's intermediate
             # files (ndjson extraction, SQLite build) do not fill the container's
             # ephemeral storage and trigger an eviction/OOM kill.
             tmp_dir = str(data_dir / "tmp")
             Path(tmp_dir).mkdir(parents=True, exist_ok=True)
 
+            sct_env = {
+                **os.environ,
+                "TRUD_API_KEY": trud_api_key,
+                "TMPDIR": tmp_dir,
+                "TEMP": tmp_dir,
+                "TMP": tmp_dir,
+            }
+
+            if dry_run:
+                self.stdout.write(
+                    f"   [DRY RUN] would run:\n"
+                    f"     sct trud download --edition {edition} --output-dir {data_dir}\n"
+                    f"     sct ndjson --rf2 <zip> --output <tmp>.ndjson\n"
+                    f"     sct sqlite --ndjson <tmp>.ndjson --output <tmp>.db\n"
+                    f"     os.replace(<tmp>.db, {snomed_db})"
+                )
+                return
+
+            # ── Step 2a: download the RF2 zip (no pipeline) ───────────────
             download_result = subprocess.run(
                 [
                     "sct",
@@ -264,18 +306,9 @@ class Command(BaseCommand):
                     edition,
                     "--output-dir",
                     str(data_dir),
-                    "--data-dir",
-                    str(data_dir),
-                    "--pipeline",
                 ],
                 text=True,
-                env={
-                    **os.environ,
-                    "TRUD_API_KEY": trud_api_key,
-                    "TMPDIR": tmp_dir,
-                    "TEMP": tmp_dir,
-                    "TMP": tmp_dir,
-                },
+                env=sct_env,
             )
 
             if download_result.returncode != 0:
@@ -287,20 +320,112 @@ class Command(BaseCommand):
                 )
                 sys.exit(download_result.returncode)
 
-            # sct writes a release-versioned filename (e.g. uk_sct2mo_42.1.0_….db).
-            # Rename it to the canonical path that SNOMED_DB_PATH points to.
-            versioned_dbs = sorted(data_dir.glob("uk_sct2mo_*.db"))
-            if versioned_dbs:
-                versioned_db = versioned_dbs[-1]
-                versioned_db.rename(snomed_db)
-                self.stdout.write(f"   Renamed {versioned_db.name} → {snomed_db.name}")
-            elif not snomed_db.exists():
+            # Locate the downloaded zip. sct writes a release-versioned name
+            # like uk_sct2mo_42.3.0_20260701000001Z.zip.
+            zips = sorted(data_dir.glob("uk_sct2mo_*.zip"))
+            if not zips:
                 self.stdout.write(
                     self.style.ERROR(
-                        f"❌ No .db file found in {data_dir} after build — rename failed."
+                        f"❌ No uk_sct2mo_*.zip found in {data_dir} after download."
                     )
                 )
                 sys.exit(1)
+            rf2_zip = zips[-1]
+            self.stdout.write(f"   Downloaded: {rf2_zip.name}")
+
+            # ── Step 2b: build NDJSON to a temp path ─────────────────────
+            ndjson_tmp = data_dir / f"{rf2_zip.stem}.ndjson"
+            self.stdout.write(f"   → Running: sct ndjson ({rf2_zip.name})")
+            ndjson_result = subprocess.run(
+                [
+                    "sct",
+                    "ndjson",
+                    "--rf2",
+                    str(rf2_zip),
+                    "--output",
+                    str(ndjson_tmp),
+                ],
+                text=True,
+                env=sct_env,
+            )
+
+            if ndjson_result.returncode != 0:
+                self.stdout.write(
+                    self.style.ERROR(
+                        f"❌ sct ndjson failed (exit {ndjson_result.returncode}).\n"
+                        "   Check the output above for details."
+                    )
+                )
+                sys.exit(ndjson_result.returncode)
+
+            if not ndjson_tmp.exists():
+                self.stdout.write(
+                    self.style.ERROR(
+                        f"❌ sct ndjson reported success but {ndjson_tmp.name} "
+                        "was not written."
+                    )
+                )
+                sys.exit(1)
+
+            # ── Step 2c: build SQLite to a fresh temp path (no lock conflict)
+            # The temp path is on the same volume as snomed.db so that
+            # os.replace() is a same-filesystem rename (atomic on POSIX).
+            sqlite_tmp = data_dir / f"{rf2_zip.stem}.db.new"
+            # Make sure we never reuse a stale temp file from a previous run.
+            if sqlite_tmp.exists():
+                sqlite_tmp.unlink()
+
+            self.stdout.write(f"   → Running: sct sqlite → {sqlite_tmp.name}")
+            sqlite_result = subprocess.run(
+                [
+                    "sct",
+                    "sqlite",
+                    "--ndjson",
+                    str(ndjson_tmp),
+                    "--output",
+                    str(sqlite_tmp),
+                ],
+                text=True,
+                env=sct_env,
+            )
+
+            if sqlite_result.returncode != 0:
+                self.stdout.write(
+                    self.style.ERROR(
+                        f"❌ sct sqlite failed (exit {sqlite_result.returncode}).\n"
+                        "   Check the output above for details."
+                    )
+                )
+                # Clean up the partial temp db so the next run starts fresh.
+                if sqlite_tmp.exists():
+                    sqlite_tmp.unlink()
+                sys.exit(sqlite_result.returncode)
+
+            if not sqlite_tmp.exists():
+                self.stdout.write(
+                    self.style.ERROR(
+                        f"❌ sct sqlite reported success but {sqlite_tmp.name} "
+                        "was not written."
+                    )
+                )
+                sys.exit(1)
+
+            # ── Step 2d: atomic swap into place ───────────────────────────
+            # os.replace is atomic on POSIX when src and dst are on the same
+            # filesystem (they are — both are in data_dir). Gunicorn workers
+            # holding read-only connections to the old inode continue to see
+            # the old snomed.db until they reconnect; new connections open the
+            # new inode. No exclusive lock is required against the live file.
+            os.replace(sqlite_tmp, snomed_db)
+            self.stdout.write(
+                f"   Atomically swapped {sqlite_tmp.name} → {snomed_db.name}"
+            )
+
+            # Clean up the NDJSON intermediate to free volume space.
+            try:
+                ndjson_tmp.unlink()
+            except OSError:
+                pass
 
             self.stdout.write(self.style.SUCCESS("✅ snomed.db rebuilt successfully."))
 

--- a/docs/self-hosting-scheduled-tasks.md
+++ b/docs/self-hosting-scheduled-tasks.md
@@ -76,19 +76,21 @@ python manage.py sync_nhs_dd_datasets --force
 python manage.py sync_nhs_dd_datasets --dataset smoking_status_code
 ```
 
-### 5. SNOMED CT Update (Optional, Manual — requires TRUD API key)
+### 5. SNOMED CT Update (Optional — requires TRUD API key)
 
-The `update_snomed_db` management command is intended to run infrequently from inside the container shell (for example monthly, or when you want to refresh terminology):
+The `update_snomed_db` management command can be run either manually or on a schedule. It is safe to run while the web app is serving traffic because the rebuild writes to a temp file and atomically swaps it into place (no exclusive SQLite lock is held against the live `snomed.db`).
 
-1. **Check for a new release** — calls `sct trud check`, which hits the TRUD API and exits immediately (exit 0) if there is nothing new. The 1.8 GB download only starts if a new release is detected (exit 2).
-2. **Download and rebuild snomed.db** — runs `sct trud download --pipeline`, producing a fresh SQLite database on the `snomed-data` volume.
+1. **Check for a new release** — calls `sct trud check`, which hits the TRUD API and exits immediately (exit 0) if there is nothing new. The 1.8 GB download only starts if a new release is detected (exit 2). This makes the command cheap to run on a schedule — most invocations are no-ops.
+2. **Download and rebuild snomed.db** — runs `sct trud download` (no `--pipeline`), then `sct ndjson` and `sct sqlite` explicitly, writing the SQLite file to a temp path on the `snomed-data` volume. The temp file is then `os.replace()`-ed over the canonical `snomed.db` atomically.
 3. **Refresh dataset descriptors** — automatically re-runs `seed_snomed_datasets --force` to update member counts and the release date in Postgres.
 
 **Optional**: If `TRUD_API_KEY` is not set the command exits cleanly.
 
-**Frequency**: Infrequent/manual is recommended for self-hosted deployments.
+**Frequency**: SNOMED CT UK is published roughly monthly. A daily or weekly scheduled run is reasonable — the preflight check makes most runs no-ops. See the Northflank / Kubernetes sections below for cron job setup.
 
-> **TRUD maintenance windows**: TRUD is offline weekdays 18:00–08:00 UK time (and midnight–06:00). Run manual updates during UK business hours to avoid false failures.
+> **Memory**: the `sct ndjson` step loads the full RF2 release into memory before writing NDJSON. UK Monolith's peak RSS during this step exceeds 4 GiB in practice — 4 GiB is *not* enough and the job will be OOM-killed (exit `-9`) partway through `sct ndjson`. Allocate **8 GiB** to the update job. The volume size is not the relevant resource for this failure.
+
+> **TRUD maintenance windows**: TRUD is offline weekdays 18:00–08:00 UK time (and midnight–06:00). Schedule the cron during UK business hours to avoid false failures.
 
 **Initial Setup**: Seed the SNOMED CT dataset descriptors once after building snomed.db:
 
@@ -304,19 +306,27 @@ Northflank provides native cron job support, making this the simplest option.
    - **Schedule**: `0 5 * * 0` (runs at 5 AM UTC every Sunday - weekly)
    - **Command**: `python manage.py sync_nhs_dd_datasets`
 
-#### 5. SNOMED CT Manual Maintenance (No Cron Job)
+#### 5. SNOMED CT Update Cron Job (Optional — requires TRUD API key)
 
-If you use SNOMED CT, run updates manually from the web service/container shell during a maintenance window:
+`update_snomed_db` is safe to run on a schedule because the rebuild writes to a temp file and atomically swaps it into place (no exclusive SQLite lock against the live `snomed.db`), and the preflight `sct trud check` makes most runs no-ops when there is no new release.
+
+1. Click **"Add Service"** → **"Cron Job"**
+2. Configure the job:
+   - **Name**: `checktick-snomed-update`
+   - **Docker Image**: Use the same image as your web service
+   - **Schedule**: `0 9 * * 1` (runs at 9 AM UTC every Monday — weekly is plenty; SNOMED CT UK publishes roughly monthly)
+   - **Command**: `python manage.py update_snomed_db --prune`
+   - **Volumes**: Mount the same `snomed-data` volume used by the web service, RW
+   - **Environment**: `TRUD_API_KEY` and `SNOMED_DB_PATH` (same values as the web service)
+   - **Resources**: Set the memory limit to **8 GiB** — the `sct ndjson` step's peak RSS exceeds 4 GiB in practice on UK Monolith, and a 4 GiB limit will OOM-kill the job (exit `-9`) partway through `sct ndjson`. The job pod is short-lived (only runs during a build), so this is a peak limit, not a steady-state cost.
+3. **Concurrency policy**: set to Forbid (a second run while one is in progress would contend for the volume).
+
+Run a one-off `--force --prune` job the first time to build `snomed.db`, then let the cron keep it current.
 
 ```bash
-# Check for a new release (no download)
-python manage.py update_snomed_db --dry-run
-
-# Rebuild safely on persistent storage with cleanup first
+# First-time build (run as a one-off job, not the cron)
 python manage.py update_snomed_db --force --prune
 ```
-
-Recommended cadence is monthly (or on demand), since releases are infrequent.
 
 #### 6. Create Global Templates Sync Cron Job
 
@@ -614,6 +624,66 @@ kubectl create job --from=cronjob/checktick-data-governance manual-test-1
 
 # Check logs
 kubectl logs -l job-name=manual-test-1
+```
+
+#### SNOMED CT update CronJob
+
+`update_snomed_db` is safe to run on a schedule: the rebuild writes to a temp file and atomically swaps it into place, so it does not conflict with gunicorn's read-only connections to the live `snomed.db`. The preflight `sct trud check` makes most runs no-ops when there is no new release.
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: checktick-snomed-update
+  namespace: checktick
+spec:
+  schedule: "0 9 * * 1" # 9 AM UTC every Monday (weekly; SNOMED UK publishes ~monthly)
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: snomed-update
+              image: ghcr.io/eatyourpeas/checktick:latest
+              command:
+                - python
+                - manage.py
+                - update_snomed_db
+                - --prune
+              envFrom:
+                - configMapRef:
+                    name: checktick-config
+                - secretRef:
+                    name: checktick-secrets
+              volumeMounts:
+                - name: snomed-data
+                  mountPath: /app/data
+              resources:
+                requests:
+                  memory: "2Gi"
+                  cpu: "250m"
+                limits:
+                  # sct ndjson's peak RSS exceeds 4 GiB on UK Monolith in
+                  # practice — 4 GiB will OOM-kill the job (exit -9) partway
+                  # through sct ndjson. 8 GiB is the proven-safe limit.
+                  # The job pod is short-lived, so this is a peak limit.
+                  memory: "8Gi"
+                  cpu: "1"
+          volumes:
+            - name: snomed-data
+              persistentVolumeClaim:
+                claimName: snomed-data
+```
+
+Run a one-off `--force --prune` job the first time to build `snomed.db`:
+
+```bash
+kubectl create job --from=cronjob/checktick-snomed-update snomed-initial-build \
+  -- /bin/sh -c "python manage.py update_snomed_db --force --prune"
 ```
 
 ---

--- a/docs/snomed-integration.md
+++ b/docs/snomed-integration.md
@@ -167,7 +167,9 @@ python manage.py seed_snomed_datasets --dry-run
 
 ### `update_snomed_db`
 
-Checks TRUD for a newer SNOMED CT UK Monolith release. If one is found, downloads and rebuilds `snomed.db` via `sct trud download --pipeline`, then updates `snomed_release_date` on all SNOMED descriptor records.
+Checks TRUD for a newer SNOMED CT UK Monolith release. If one is found, downloads and rebuilds `snomed.db`, then updates `snomed_release_date` on all SNOMED descriptor records.
+
+The rebuild is performed as three explicit steps (`sct trud download`, `sct ndjson`, `sct sqlite`) rather than `sct trud download --pipeline`. The final `sct sqlite` step writes to a temp file on the same volume as `snomed.db`, then `os.replace()` atomically swaps it into place. This avoids a SQLite `SQLITE_BUSY` ("database is locked") failure when gunicorn workers hold read-only connections to the existing `snomed.db` — the live file is never locked for writing. As a result the command is **safe to run while the web app is serving traffic**, and is suitable for a scheduled job.
 
 Use `--prune` when running updates on constrained volumes. It removes stale `tmp/`, downloaded zip files, and old versioned `uk_sct2*.db` artefacts before the update check/build starts.
 
@@ -178,9 +180,9 @@ python manage.py update_snomed_db --dry-run  # check for new release only
 python manage.py update_snomed_db --force --prune  # free space before rebuild
 ```
 
-SNOMED CT UK is published infrequently. For self-hosted deployments, prefer a **manual in-container update** during a planned maintenance window (for example monthly or only when you want to refresh terminology), rather than a scheduled cron job.
+The command's preflight step (`sct trud check`) is a lightweight API call that returns "up to date" without downloading anything when there is no new release. This makes the command cheap to run on a schedule — most invocations are no-ops. SNOMED CT UK is published roughly monthly, so a daily or weekly scheduled run is reasonable. See [Scheduled Tasks](self-hosting-scheduled-tasks.md) for Northflank setup.
 
-See [Scheduled Tasks](self-hosting-scheduled-tasks.md) for Northflank setup.
+> **Memory note:** the `sct ndjson` step loads the full RF2 release into memory before writing NDJSON. UK Monolith's peak RSS during this step exceeds 4 GiB in practice — 4 GiB is *not* enough and the job will be OOM-killed (exit `-9`) partway through `sct ndjson`. Allocate **8 GiB** to the update job. The volume size is not the relevant resource for this failure.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "checktick"
-version = "0.7.10"
+version = "0.7.11"
 description = "Secure, server-rendered survey platform for medical audit and research"
 authors = ["CheckTick Maintainers <simon@eatyourpeas.co.uk>"]
 readme = "README.md"

--- a/tests/test_snomed_integration.py
+++ b/tests/test_snomed_integration.py
@@ -12,6 +12,7 @@ All tests are offline — no real snomed.db required.
 """
 
 from io import StringIO
+import os
 import sqlite3
 from types import SimpleNamespace
 
@@ -527,3 +528,156 @@ def test_update_command_dry_run_no_db_path(monkeypatch):
             call_command("update_snomed_db", dry_run=True, stdout=out)
     assert exc_info.value.code == 1
     assert "SNOMED_DB_PATH" in out.getvalue()
+
+
+@pytest.mark.django_db
+def test_update_command_dry_run_shows_explicit_steps(tmp_path, monkeypatch):
+    """Dry-run output describes the explicit ndjson/sqlite/swap steps.
+
+    This guards the move away from `sct trud download --pipeline` toward the
+    explicit two-step build + atomic swap, which avoids SQLITE_BUSY when
+    gunicorn workers hold read-only connections to the live snomed.db.
+
+    Uses --force so the dry-run flows through the check step and reaches the
+    build section that prints the explicit step descriptions.
+    """
+    db_path = tmp_path / "snomed.db"
+    db_path.touch()
+    out = StringIO()
+    with override_settings(SNOMED_DB_PATH=str(db_path), TRUD_API_KEY="dummy-key"):
+        call_command("update_snomed_db", force=True, dry_run=True, stdout=out)
+    text = out.getvalue()
+    # The dry-run should mention each explicit step, not --pipeline.
+    assert "sct ndjson" in text
+    assert "sct sqlite" in text
+    assert "os.replace" in text
+    assert "--pipeline" not in text
+
+
+@pytest.mark.django_db
+def test_update_command_builds_to_temp_then_atomically_swaps(tmp_path, monkeypatch):
+    """The build writes SQLite to a temp path, then os.replace()s it into place.
+
+    Verifies the lock-conflict fix: sct sqlite must never write directly to the
+    canonical snomed.db path (which gunicorn holds read-only). Instead it writes
+    to <stem>.db.new on the same volume, and the management command atomically
+    swaps it into place.
+    """
+    db_path = tmp_path / "snomed.db"
+    db_path.touch()
+    zip_path = tmp_path / "uk_sct2mo_42.3.0_20260701000001Z.zip"
+    zip_path.touch()
+
+    # Track the subprocess invocations and the temp sqlite output path.
+    seen_cmds: list[list[str]] = []
+    sqlite_tmp_path_holder: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):
+        seen_cmds.append(cmd)
+        # Simulate sct ndjson writing the NDJSON intermediate file.
+        if cmd[:2] == ["sct", "ndjson"]:
+            out_flag = cmd.index("--output")
+            ndjson_tmp = cmd[out_flag + 1]
+            with open(ndjson_tmp, "w") as fh:
+                fh.write("{\"_type\":\"sct_provenance\"}\n")
+        # Simulate sct sqlite writing the temp db file.
+        if cmd[:2] == ["sct", "sqlite"]:
+            out_flag = cmd.index("--output")
+            sqlite_tmp = cmd[out_flag + 1]
+            sqlite_tmp_path_holder["path"] = sqlite_tmp
+            # Write a real (empty) SQLite db so the subsequent
+            # seed_snomed_datasets call can open it without error.
+            conn = sqlite3.connect(sqlite_tmp)
+            conn.execute("CREATE TABLE concepts (id TEXT PRIMARY KEY, preferred_term TEXT, active INTEGER)")
+            conn.execute("CREATE TABLE refset_members (refset_id TEXT, referenced_component_id TEXT)")
+            conn.execute("CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT)")
+            conn.execute("INSERT INTO metadata (key, value) VALUES ('release_date', '2026-07-01')")
+            conn.commit()
+            conn.close()
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    replaced: dict[str, object] = {}
+    real_replace = os.replace
+
+    def fake_replace(src, dst):
+        replaced["src"] = str(src)
+        replaced["dst"] = str(dst)
+        real_replace(src, dst)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr("os.replace", fake_replace)
+
+    out = StringIO()
+    with override_settings(SNOMED_DB_PATH=str(db_path), TRUD_API_KEY="dummy-key"):
+        call_command("update_snomed_db", force=True, stdout=out)
+
+    # 1. The download step must NOT use --pipeline.
+    download_cmd = next(c for c in seen_cmds if c[:3] == ["sct", "trud", "download"])
+    assert "--pipeline" not in download_cmd
+
+    # 2. sct sqlite must write to a temp path, NOT the canonical snomed.db.
+    sqlite_cmd = next(c for c in seen_cmds if c[:2] == ["sct", "sqlite"])
+    out_flag = sqlite_cmd.index("--output")
+    sqlite_out = sqlite_cmd[out_flag + 1]
+    assert sqlite_out != str(db_path), (
+        "sct sqlite must not write to the canonical snomed.db path — "
+        "that causes SQLITE_BUSY when gunicorn holds read-only connections."
+    )
+    assert sqlite_out.endswith(".db.new"), (
+        f"sct sqlite output should be a .db.new temp path, got {sqlite_out}"
+    )
+
+    # 3. The temp path must be on the same filesystem as snomed.db so that
+    #    os.replace is an atomic rename (not a copy).
+    assert os.path.dirname(sqlite_out) == str(tmp_path)
+
+    # 4. os.replace must swap the temp file into the canonical path.
+    assert replaced["src"] == sqlite_tmp_path_holder["path"]
+    assert replaced["dst"] == str(db_path)
+
+    # 5. The canonical snomed.db is now a valid SQLite db (the one sct sqlite
+    #    wrote to the temp path, then os.replace'd into place).
+    conn = sqlite3.connect(str(db_path))
+    tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert "concepts" in tables
+    assert "metadata" in tables
+    conn.close()
+
+    # 6. The temp file is gone after the swap.
+    assert not os.path.exists(sqlite_out)
+
+
+@pytest.mark.django_db
+def test_update_command_sqlite_failure_cleans_temp_and_exits(tmp_path, monkeypatch):
+    """If sct sqlite fails, the partial temp db is removed and the command exits non-zero.
+
+    Prevents a stale .db.new from a failed run causing confusion on the next run.
+    """
+    db_path = tmp_path / "snomed.db"
+    db_path.touch()
+    zip_path = tmp_path / "uk_sct2mo_42.3.0_20260701000001Z.zip"
+    zip_path.touch()
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:2] == ["sct", "sqlite"]:
+            out_flag = cmd.index("--output")
+            sqlite_tmp = cmd[out_flag + 1]
+            # Simulate sct sqlite writing a partial file then failing.
+            with open(sqlite_tmp, "wb") as fh:
+                fh.write(b"partial")
+            return SimpleNamespace(returncode=1, stdout="", stderr="boom")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    out = StringIO()
+    with override_settings(SNOMED_DB_PATH=str(db_path), TRUD_API_KEY="dummy-key"):
+        with pytest.raises(SystemExit) as exc_info:
+            call_command("update_snomed_db", force=True, stdout=out)
+
+    assert exc_info.value.code == 1
+    # The partial temp db must have been cleaned up.
+    leftover = list(tmp_path.glob("*.db.new"))
+    assert leftover == [], f"Expected no stale .db.new files, found {leftover}"
+    # The canonical snomed.db must be untouched.
+    assert db_path.exists()

--- a/tests/test_snomed_integration.py
+++ b/tests/test_snomed_integration.py
@@ -579,7 +579,7 @@ def test_update_command_builds_to_temp_then_atomically_swaps(tmp_path, monkeypat
             out_flag = cmd.index("--output")
             ndjson_tmp = cmd[out_flag + 1]
             with open(ndjson_tmp, "w") as fh:
-                fh.write("{\"_type\":\"sct_provenance\"}\n")
+                fh.write('{"_type":"sct_provenance"}\n')
         # Simulate sct sqlite writing the temp db file.
         if cmd[:2] == ["sct", "sqlite"]:
             out_flag = cmd.index("--output")
@@ -588,10 +588,16 @@ def test_update_command_builds_to_temp_then_atomically_swaps(tmp_path, monkeypat
             # Write a real (empty) SQLite db so the subsequent
             # seed_snomed_datasets call can open it without error.
             conn = sqlite3.connect(sqlite_tmp)
-            conn.execute("CREATE TABLE concepts (id TEXT PRIMARY KEY, preferred_term TEXT, active INTEGER)")
-            conn.execute("CREATE TABLE refset_members (refset_id TEXT, referenced_component_id TEXT)")
+            conn.execute(
+                "CREATE TABLE concepts (id TEXT PRIMARY KEY, preferred_term TEXT, active INTEGER)"
+            )
+            conn.execute(
+                "CREATE TABLE refset_members (refset_id TEXT, referenced_component_id TEXT)"
+            )
             conn.execute("CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT)")
-            conn.execute("INSERT INTO metadata (key, value) VALUES ('release_date', '2026-07-01')")
+            conn.execute(
+                "INSERT INTO metadata (key, value) VALUES ('release_date', '2026-07-01')"
+            )
             conn.commit()
             conn.close()
         return SimpleNamespace(returncode=0, stdout="", stderr="")
@@ -623,9 +629,9 @@ def test_update_command_builds_to_temp_then_atomically_swaps(tmp_path, monkeypat
         "sct sqlite must not write to the canonical snomed.db path — "
         "that causes SQLITE_BUSY when gunicorn holds read-only connections."
     )
-    assert sqlite_out.endswith(".db.new"), (
-        f"sct sqlite output should be a .db.new temp path, got {sqlite_out}"
-    )
+    assert sqlite_out.endswith(
+        ".db.new"
+    ), f"sct sqlite output should be a .db.new temp path, got {sqlite_out}"
 
     # 3. The temp path must be on the same filesystem as snomed.db so that
     #    os.replace is an atomic rename (not a copy).
@@ -638,7 +644,10 @@ def test_update_command_builds_to_temp_then_atomically_swaps(tmp_path, monkeypat
     # 5. The canonical snomed.db is now a valid SQLite db (the one sct sqlite
     #    wrote to the temp path, then os.replace'd into place).
     conn = sqlite3.connect(str(db_path))
-    tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    tables = {
+        row[0]
+        for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }
     assert "concepts" in tables
     assert "metadata" in tables
     conn.close()


### PR DESCRIPTION


- Pin SCT_REPO=pacharanero/sct and SCT_VERSION=v0.20.1 in Dockerfile,
  Dockerfile.dev, and Dockerfile.registry (was eatyourpeas/sct fork at
  v0.3.11-ctfix3).
- Rewrite update_snomed_db to drop `sct trud download --pipeline` in
  favour of explicit ndjson + sqlite steps with an atomic os.replace()
  swap into snomed.db. The pipeline mode wrote SQLite directly to the
  canonical path, which gunicorn workers hold open read-only, causing
  SQLITE_BUSY ("database is locked") failures. The new flow builds to a
  temp file on the same volume and atomically renames it into place, so
  no exclusive lock is ever held against the live snomed.db. This makes
  the command safe to run while the web app is serving traffic and
  suitable for a scheduled job.
- Document the cron-friendly workflow and the 8 GiB memory requirement
  for the update job (sct ndjson's peak RSS exceeds 4 GiB on UK
  Monolith in practice) in docs/snomed-integration.md and
  docs/self-hosting-scheduled-tasks.md, including Northflank and
  Kubernetes CronJob manifests.
- Add tests covering the dry-run output, the atomic-swap build flow, and
  temp-file cleanup on sct sqlite failure.
