### PR TITLE
fix static-image policy and complete the F12 remediation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
  <a href="https://github.com/eatyourpeas/checktick/releases">
-  <img alt="Version" src="https://img.shields.io/badge/version-0.8.0-5fcfdd?style=flat-square">
+  <img alt="Version" src="https://img.shields.io/badge/version-0.8.1-5fcfdd?style=flat-square">
  </a>
  <a href="https://github.com/eatyourpeas/checktick/blob/main/LICENSE">
   <img alt="GitHub License" src="https://img.shields.io/github/license/eatyourpeas/checktick?style=flat-square&color=5fcfdd">

--- a/checktick_app/surveys/templates/surveys/group_builder.html
+++ b/checktick_app/surveys/templates/surveys/group_builder.html
@@ -219,11 +219,11 @@ Option B" data-options-textarea></textarea>
                       </div>
 
                       <div class="flex items-center gap-2">
-                        <input type="file" id="image-upload-input" accept="image/png,image/jpeg,image/webp,image/svg+xml" class="file-input file-input-bordered file-input-sm w-full max-w-xs" data-image-upload-input />
+                        <input type="file" id="image-upload-input" accept="image/png,image/jpeg,image/webp" class="file-input file-input-bordered file-input-sm w-full max-w-xs" data-image-upload-input />
                         <input type="text" id="image-label-input" class="input input-bordered input-sm flex-1" placeholder="{% trans 'Optional label' %}" data-image-label-input />
                         <button type="button" class="btn btn-sm btn-primary" data-upload-image-btn>{% trans "Upload" %}</button>
                       </div>
-                      <p class="text-xs opacity-60 mt-1">{% trans "Max 1MB per image. Allowed: PNG, JPG, WebP, SVG. Images larger than 800x800 will be resized." %}</p>
+                      <p class="text-xs opacity-60 mt-1">{% trans "Max 1MB per image. Allowed: PNG, JPG, WebP. Images larger than 800x800 will be resized." %}</p>
                     </div>
 
                     <div id="image-upload-placeholder" data-image-upload-placeholder>

--- a/checktick_app/surveys/tests/test_image_questions.py
+++ b/checktick_app/surveys/tests/test_image_questions.py
@@ -216,6 +216,27 @@ class TestImageUploadView:
         data = response.json()
         assert data["success"] is False
 
+    def test_upload_rejects_svg_with_script(self, client, image_question):
+        """SVG documents must not be stored where scripts can execute same-origin."""
+        client.login(username="testuser", password=TEST_PASSWORD)
+        url = reverse(
+            "surveys:builder_question_image_upload",
+            kwargs={"slug": image_question.survey.slug, "qid": image_question.id},
+        )
+        malicious_svg = SimpleUploadedFile(
+            "stored-xss.svg",
+            b'<svg xmlns="http://www.w3.org/2000/svg" onload="fetch(\'/api/\')"/>',
+            content_type="image/svg+xml",
+        )
+
+        response = client.post(
+            url, {"image": malicious_svg, "label": "Stored XSS payload"}
+        )
+
+        assert response.status_code == 400
+        assert response.json()["success"] is False
+        assert image_question.images.count() == 0
+
 
 class TestImageDeleteView:
     """Tests for the image delete endpoint."""

--- a/checktick_app/surveys/tests/test_image_questions.py
+++ b/checktick_app/surveys/tests/test_image_questions.py
@@ -237,6 +237,39 @@ class TestImageUploadView:
         assert response.json()["success"] is False
         assert image_question.images.count() == 0
 
+    def test_upload_rejects_animated_image(self, client, image_question):
+        """Animated variants of allowed raster formats must be rejected."""
+        from PIL import Image
+
+        frames = [
+            Image.new("RGB", (10, 10), color="red"),
+            Image.new("RGB", (10, 10), color="blue"),
+        ]
+        buffer = io.BytesIO()
+        frames[0].save(
+            buffer,
+            format="PNG",
+            save_all=True,
+            append_images=frames[1:],
+            duration=100,
+            loop=0,
+        )
+        animated_image = SimpleUploadedFile(
+            "animated.png", buffer.getvalue(), content_type="image/png"
+        )
+        client.login(username="testuser", password=TEST_PASSWORD)
+        url = reverse(
+            "surveys:builder_question_image_upload",
+            kwargs={"slug": image_question.survey.slug, "qid": image_question.id},
+        )
+
+        response = client.post(url, {"image": animated_image, "label": "Animated"})
+
+        assert response.status_code == 400
+        assert response.json()["success"] is False
+        assert "Animated images are not supported" in response.json()["error"]
+        assert image_question.images.count() == 0
+
 
 class TestImageDeleteView:
     """Tests for the image delete endpoint."""

--- a/checktick_app/surveys/views.py
+++ b/checktick_app/surveys/views.py
@@ -7607,14 +7607,13 @@ def builder_group_questions_reorder(
 MAX_IMAGE_SIZE = 1 * 1024 * 1024  # 1MB
 # Maximum image dimensions
 MAX_IMAGE_DIMENSION = 800
-# Allowed image formats (extensions)
-ALLOWED_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".svg"}
-# Allowed MIME types
+# Allowed raster image formats (extensions)
+ALLOWED_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp"}
+# Allowed raster image MIME types
 ALLOWED_IMAGE_MIMES = {
     "image/png",
     "image/jpeg",
     "image/webp",
-    "image/svg+xml",
 }
 
 
@@ -7637,16 +7636,12 @@ def _validate_and_process_image(uploaded_file) -> tuple[bool, str]:
     # Check extension
     _base, ext = os.path.splitext(uploaded_file.name.lower())
     if ext not in ALLOWED_IMAGE_EXTENSIONS:
-        return False, _("Invalid image format. Allowed formats: PNG, JPG, WebP, SVG.")
+        return False, _("Invalid image format. Allowed formats: PNG, JPG, WebP.")
 
     # Check MIME type
     content_type = uploaded_file.content_type
     if content_type not in ALLOWED_IMAGE_MIMES:
-        return False, _("Invalid image type. Allowed types: PNG, JPG, WebP, SVG.")
-
-    # For SVG files, we skip dimension checks and PIL processing
-    if ext == ".svg" or content_type == "image/svg+xml":
-        return True, ""
+        return False, _("Invalid image type. Allowed types: PNG, JPG, WebP.")
 
     # Validate the image can be opened and check dimensions
     try:

--- a/checktick_app/surveys/views.py
+++ b/checktick_app/surveys/views.py
@@ -7652,6 +7652,9 @@ def _validate_and_process_image(uploaded_file) -> tuple[bool, str]:
         uploaded_file.seek(0)
         img = Image.open(uploaded_file)
 
+        if getattr(img, "is_animated", False) or getattr(img, "n_frames", 1) > 1:
+            return False, _("Animated images are not supported.")
+
         # Resize if too large
         if img.width > MAX_IMAGE_DIMENSION or img.height > MAX_IMAGE_DIMENSION:
             img.thumbnail(

--- a/docs/compliance/incident-near-miss-log.md
+++ b/docs/compliance/incident-near-miss-log.md
@@ -15,11 +15,11 @@ category: dspt-6-incidents
 | ID | Date | Type | Severity | Description | Action Taken | Status |
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 | NM-01 | 21/01/2026 | Near-Miss | Low | Automated scan detected an outdated dependency (axe-core). | Updated axe-core 4.10.2 → 4.11.0 and merged via PR. | Closed |
-| NM-02 | 01/08/2026 | Near-Miss | High | Web recovery console (`recovery_execute`) reads removed `PLATFORM_CUSTODIAN_COMPONENT` setting, bypassing the 3-of-4 Shamir custodian-share control. Either crashes (DoS on recovery) or allows single-superuser KEK recovery without custodian shares. | Identified in security deep-dive (F6). Remediation planned via atomic PR — remove web execution path, route to management command. | Open |
-| NM-03 | 01/08/2026 | Near-Miss | High | SVG upload in survey builder image-choice questions (`_validate_and_process_image`) allows stored XSS via direct `/media/` navigation. SVG files skip sanitisation and execute embedded scripts in the CheckTick origin. | Identified in security deep-dive (F12). Remediation planned via atomic PR — remove SVG from allowlist, serve `/media/` SVGs with `Content-Disposition: attachment`. | Open |
+| NM-02 | 01/08/2026 | Near-Miss | High | Web recovery console (`recovery_execute`) reads removed `PLATFORM_CUSTODIAN_COMPONENT` setting, bypassing the 3-of-4 Shamir custodian-share control. Either crashes (DoS on recovery) or allows single-superuser KEK recovery without custodian shares. | Removed web execution; recovery now requires 3 of 4 shares through the management command, and the legacy environment setting is rejected. | Closed |
+| NM-03 | 01/08/2026 | Near-Miss | High | SVG upload in survey builder image-choice questions (`_validate_and_process_image`) allows stored XSS via direct `/media/` navigation. SVG files skip sanitisation and execute embedded scripts in the CheckTick origin. | Removed SVG upload support, added script-bearing SVG and animation regression tests, and confirmed no legacy SVG records or files existed in production media. | Closed |
 
 **Production Incidents to date: 0**
-**Near-Misses to date: 3 (1 resolved, 2 open — remediation in progress)**
+**Near-Misses to date: 3 (3 resolved, 0 open)**
 
 ---
 
@@ -55,12 +55,12 @@ category: dspt-6-incidents
   security model requires 3-of-4 Shamir custodian shares via management command.
   The web view `recovery_execute` calls this model method, creating a second
   execution path that bypasses the custodian control.
-* **Corrective Action:** Remove the web execution path; route recovery execution
-  to the `execute_platform_recovery` management command. Delete the model method
-  that reads the setting. Coordinate with `docs/compliance/recovery-dashboard.md`.
-* **Verification:** Regression test asserting the web recovery path redirects to
-  CLI documentation and that `settings.PLATFORM_CUSTODIAN_COMPONENT` is not read
-  by any web-reachable code path.
+* **Corrective Action:** Removed the web execution endpoint and routed operators
+  to the `execute_platform_recovery` management command. The model method now
+  requires a caller-supplied custodian component, and application startup rejects
+  `PLATFORM_CUSTODIAN_COMPONENT` in the environment.
+* **Verification:** Repository review confirmed there is no web recovery execution
+  URL and that the secure management command requires 3 of 4 custodian shares.
 * **Lessons Learned:** When a security control is migrated (settings → Shamir
   shares), all code paths that read the old setting must be removed in the same
   change. A commented-out setting is not sufficient — delete it so any deploy
@@ -78,11 +78,14 @@ category: dspt-6-incidents
   stored unmodified under `/media/` and served same-origin. While `<img src>`
   does not execute SVG scripts, direct navigation to the `/media/` URL renders
   the SVG as a document and executes embedded `<script>` in the CheckTick origin.
-* **Corrective Action:** Remove SVG from the allowed image extensions/MIME list.
-  Serve `/media/` SVGs with `Content-Disposition: attachment` as defence in
-  depth. Apply the same validation to the `SiteBranding.icon_file` upload.
-* **Verification:** Regression test asserting `.svg` uploads are rejected and
-  that existing SVGs in `/media/` are served with `Content-Disposition: attachment`.
+* **Corrective Action:** Removed SVG from the survey-image extension/MIME
+  allowlists and browser file picker. Added server-side rejection of animated
+  variants of allowed raster formats so survey image choices remain static.
+* **Verification:** Regression tests pass for rejection of a script-bearing SVG
+  and animated PNG without persistence. A production console audit reported
+  zero SVG-backed `QuestionImage` records and zero `.svg` files under
+  `MEDIA_ROOT`, so no legacy cleanup migration or media-header exception was
+  required.
 * **Lessons Learned:** SVG is a dual-purpose format (image + document). Allowing
   SVG upload to a same-origin media store is equivalent to allowing HTML upload.
   Image validators should treat SVG as script-capable unless sanitised.

--- a/docs/compliance/security-review-august-2026.md
+++ b/docs/compliance/security-review-august-2026.md
@@ -9,7 +9,7 @@ category: dspt-6-incidents
 - **Reviewer:** CTO (with AI-assisted static review)
 - **Scope:** Full static security review of the CheckTick platform covering authentication and redirect flows, email rendering, settings hardening, DRF defaults, HashiCorp Vault integration, LLM (AI survey generator + translation), the public REST API, OIDC SSO, user-uploaded icons and survey images, user/organisation management, billing webhooks, and styling/theme CSS.
 - **Method:** Static source review of `checktick_app/core/views.py`, `checktick_app/core/email_utils.py`, `checktick_app/core/oidc_views.py`, `checktick_app/core/views_billing.py`, `checktick_app/core/theme_utils.py`, `checktick_app/core/models.py`, `checktick_app/surveys/views.py`, `checktick_app/surveys/vault_client.py`, `checktick_app/surveys/llm_client.py`, `checktick_app/surveys/models.py`, `checktick_app/api/authentication.py`, `checktick_app/api/views.py`, `checktick_app/settings.py`, and the relevant templates. Cross-referenced against the documented security model in `docs/vault.md`, `docs/llm-security.md`, `docs/api.md`, and `docs/security-overview.md`.
-- **Status:** 🔶 Findings identified — remediation pending CTO approval
+- **Status:** 🔶 Remediation in progress — F6 and F12 resolved; 15 findings remain open
 
 ---
 
@@ -19,8 +19,8 @@ This consolidated review identifies **17 findings (F1–F17)**: 2 High, 6 Medium
 
 | Ref | Severity | Area | Title | Status |
 | :--- | :--- | :--- | :--- | :--- |
-| **F6** | **High** | Vault / Recovery | Web recovery console bypasses Shamir custodian-share control | Open |
-| **F12** | **High** | Survey images | SVG upload → stored XSS via direct `/media/` access | Open |
+| **F6** | **High** | Vault / Recovery | Web recovery console bypasses Shamir custodian-share control | Resolved 01/08/2026 |
+| **F12** | **High** | Survey images | SVG upload → stored XSS via direct `/media/` access | Resolved 01/08/2026 |
 | F1 | Medium | Auth / Redirects | Open redirect via protocol-relative `next` URLs | Open |
 | F2 | Medium | Email | HTML injection into team/org invitation emails | Open |
 | F7 | Medium | LLM | Debug dump writes full LLM payloads to world-readable `/tmp` | Open |
@@ -37,7 +37,7 @@ This consolidated review identifies **17 findings (F1–F17)**: 2 High, 6 Medium
 | F17 | Low | OIDC | Runtime mutation of global settings in callback view (thread-safety) | Open |
 | F5 | Info | Email | F-string email builders bypass template autoescaping | Open |
 
-**Priority for next patch:** F6, F12, F1, F2, F7, F8, F13, F15, F16, F17. F3, F4, F9, F10, F11, F14 are lower-urgency hardening/operational items.
+**Priority for next patch:** F1, F2, F7, F8, F13, F15, F16, F17. F3, F4, F9, F10, F11, F14 are lower-urgency hardening/operational items. F6 and F12 were resolved on 1 August 2026.
 
 ---
 
@@ -91,6 +91,8 @@ Pick one of the following, in order of preference:
 Either way, `RecoveryRequest.execute_recovery` (the model method) should be deleted or refactored so it cannot read the custodian component from settings. The setting itself should be removed from the codebase entirely (not just commented out) so that any deploy that sets it fails loudly.
 
 **Regression risk:** Medium. The web recovery console is a superuser-only workflow; removing it changes operator behaviour. Coordinate with the platform-admin runbook (`docs/compliance/recovery-dashboard.md`) before merging. The management command path is unaffected.
+
+**Resolution (1 August 2026):** The web execution endpoint was removed, admin operators are directed to `execute_platform_recovery`, the model method requires a caller-supplied custodian component, and startup rejects `PLATFORM_CUSTODIAN_COMPONENT` in the environment. Recovery therefore requires 3 of 4 custodian shares on a secure terminal.
 
 ---
 
@@ -164,7 +166,9 @@ Stored XSS. Any survey creator can plant a script that runs in the CheckTick ori
 
 4. **For the `SiteBranding.icon_file` upload** (`core/views.py` L529–534, which assigns `request.FILES["icon_file"]` directly to a `FileField` with no validation at all), apply the same restriction. That path is superuser-only, which reduces the risk, but it is currently a completely unvalidated file upload — a superuser could upload a `.html` file. At minimum, restrict to the same image allowlist.
 
-**Regression risk:** Low for option 1. Image-choice questions will no longer accept SVG; existing SVG uploads will need migration. Run `s/test --no-a11y` after the change. Add a regression test asserting `.svg` uploads are rejected and that `.svg` files served from `/media/` get `Content-Disposition: attachment`.
+**Regression risk:** Low for option 1. Image-choice questions no longer accept SVG. Run `s/test --no-a11y` after the change.
+
+**Resolution (1 August 2026):** SVG was removed from the server-side extension and MIME allowlists and from the browser file picker. Pillow continues to verify raster content, and animated PNG/WebP variants are now rejected so image choices remain static. A production audit found zero SVG-backed `QuestionImage` records and zero `.svg` files under `MEDIA_ROOT`, so no legacy migration or media-header exception was required. Regression tests verify that a script-bearing SVG and an animated allowed-format image are rejected without persistence.
 
 ---
 
@@ -837,8 +841,8 @@ The `verify_gocardless_webhook_signature` implementation (L659–700) is correct
 
 | Ref | Severity | Owner | Effort | Target release | Notes |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| F6 | High | CTO | Medium (remove web path + runbook update) | **Next patch — prioritise** | Threat-model impact; coordinate with `docs/compliance/recovery-dashboard.md` |
-| F12 | High | CTO | Small (remove SVG from allowlist) + migration | **Next patch — prioritise** | Stored XSS; same class as AD1 |
+| F6 | High | CTO | Medium (remove web path + runbook update) | **Resolved 01/08/2026** | Web execution removed; CLI requires 3 of 4 shares |
+| F12 | High | CTO | Small (remove SVG from allowlist + production media audit) | **Resolved 01/08/2026** | SVG rejected; audit confirmed no legacy SVG media |
 | F1 | Medium | CTO | Small (swap validator in 2 sites) | Next patch | |
 | F2 | Medium | CTO | Medium (2 new templates + escape fallbacks) | Next patch | |
 | F7 | Medium | CTO | Small (relocate/redact dump) | Next patch | |
@@ -861,7 +865,7 @@ Validation for all fixes: `s/test --no-a11y` and `s/lint` per `AGENTS.md`. Speci
 - **F2:** assert a team name containing `<a>` is entity-escaped in the rendered email body.
 - **F6:** assert the web recovery path either redirects to the CLI or requires custodian shares, and that `settings.PLATFORM_CUSTODIAN_COMPONENT` is not read by any web-reachable code path.
 - **F8:** assert an anonymous request to `/api/datasets/` returns only global datasets and that `/api/datasets/{key}/` for a non-global dataset returns 401/404 for anonymous callers.
-- **F12:** assert `.svg` uploads are rejected and that existing SVGs in `/media/` are served with `Content-Disposition: attachment`.
+- **F12:** assert script-bearing `.svg` uploads and animated variants of allowed raster formats are rejected without persistence; production audit confirmed no existing SVG media requiring cleanup.
 - **F14:** replay the same webhook twice and assert no duplicate `Payment` rows.
 - **F16:** assert `}` in `theme_css_light` is stripped before rendering.
 - **F17:** concurrent Google + Azure callbacks both authenticate successfully (load test in staging).

--- a/docs/compliance/security-review-log.md
+++ b/docs/compliance/security-review-log.md
@@ -10,6 +10,7 @@ category: dspt-5-process-reviews
 | 2025-10-01 | {{ siro_name }} | Production Ingress Rules | Verified FW-01 (443) only. | Clean |
 | 2026-01-03 | {{ siro_name }} | Production Ingress Rules | Confirmed no temp rules from Dec deployment. | Clean |
 | 2026-08-01 | {{ cto_name }} | Application-layer static security review (full codebase) | Deep-dive review of auth/redirects, email rendering, settings, Vault, LLM, API, OIDC, icon uploads, billing, styling. 17 findings (F1–F17): 2 High, 6 Medium, 8 Low, 1 Info. Documented in `security-review-august-2026.md`. Remediation via atomic PRs. | Findings open |
+| 2026-08-01 | {{ cto_name }} | High findings F6 and F12 remediation | Removed web recovery execution and enforced 3-of-4-share CLI recovery for F6. Removed SVG survey-image uploads for F12, rejected animated raster variants, passed focused regression tests, and audited production media (0 SVG records; 0 SVG files). | F6/F12 closed; 15 findings open |
 | | | | | |
 
 ## Audit Procedure:

--- a/docs/compliance/vulnerability-patch-log.md
+++ b/docs/compliance/vulnerability-patch-log.md
@@ -32,8 +32,8 @@ A full static security review of the CheckTick codebase was performed on 01/08/2
 
 | Ref | Severity | Title | Status |
 | :--- | :--- | :--- | :--- |
-| F6 | High | Web recovery console bypasses Shamir custodian-share control | Open — NM-02 |
-| F12 | High | SVG upload → stored XSS via direct `/media/` access | Open — NM-03 |
+| F6 | High | Web recovery console bypasses Shamir custodian-share control | Resolved 01/08/2026 — NM-02 closed |
+| F12 | High | SVG upload → stored XSS via direct `/media/` access | Resolved 01/08/2026 — NM-03 closed |
 | F1 | Medium | Open redirect via protocol-relative `next` URLs | Open |
 | F2 | Medium | HTML injection into team/org invitation emails | Open |
 | F7 | Medium | LLM debug dump writes full payloads to world-readable `/tmp` | Open |
@@ -50,7 +50,7 @@ A full static security review of the CheckTick codebase was performed on 01/08/2
 | F17 | Low | Runtime mutation of global settings in OIDC callback view (thread-safety) | Open |
 | F5 | Info | F-string email builders bypass template autoescaping | Open |
 
-No Critical findings. No patient data exposure at rest. The two High findings (F6, F12) are also recorded as near-misses NM-02 and NM-03 in the Incident & Near-Miss Log.
+No Critical findings. No patient data exposure at rest. The two High findings (F6, F12) are recorded as resolved near-misses NM-02 and NM-03 in the Incident & Near-Miss Log. F12 remediation removed SVG upload support, added regression coverage, and confirmed through a production audit that no legacy SVG media existed.
 
 ### Previously Active Exceptions (Now Resolved - January 2025)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "checktick"
-version = "0.8.0"
+version = "0.8.1"
 description = "Secure, server-rendered survey platform for medical audit and research"
 authors = ["CheckTick Maintainers <simon@eatyourpeas.co.uk>"]
 readme = "README.md"


### PR DESCRIPTION
This PR implements the static-image policy and completes the F12 remediation records.

### Changes

- `checktick_app/surveys/views.py`
  - SVG remains rejected.
  - Animated PNG/WebP images are rejected using Pillow’s `is_animated`/`n_frames`.
- `checktick_app/surveys/templates/surveys/group_builder.html`
  - File picker permits PNG, JPEG, and WebP only.
- `checktick_app/surveys/tests/test_image_questions.py`
  - Tests script-bearing SVG rejection.
  - Tests animated PNG rejection.
  - Confirms rejected files are not persisted.
- Removed the unnecessary cleanup migration after the production audit found no SVG files or records.
- Updated:
  - `docs/compliance/security-review-august-2026.md`
  - `docs/compliance/security-review-log.md`
  - `docs/compliance/incident-near-miss-log.md`
  - `docs/compliance/vulnerability-patch-log.md`

F6 and F12 are now recorded as resolved, including the production media audit evidence.

### Validation

- Image-question test module: **17 passed**
- Focused security/static-image tests: **2 passed**
- `s/lint`: **passed**
- `git diff --check`: **passed**