### PR TITLE
Security/f1 signup redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
  <a href="https://github.com/eatyourpeas/checktick/releases">
-  <img alt="Version" src="https://img.shields.io/badge/version-0.8.1-5fcfdd?style=flat-square">
+  <img alt="Version" src="https://img.shields.io/badge/version-0.8.2-5fcfdd?style=flat-square">
  </a>
  <a href="https://github.com/eatyourpeas/checktick/blob/main/LICENSE">
   <img alt="GitHub License" src="https://img.shields.io/github/license/eatyourpeas/checktick?style=flat-square&color=5fcfdd">

--- a/checktick_app/core/views.py
+++ b/checktick_app/core/views.py
@@ -12,6 +12,7 @@ from django.db.models import Q
 from django.http import JsonResponse
 from django.shortcuts import redirect, render
 from django.utils import timezone, translation
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 
 from checktick_app.surveys.models import (
@@ -704,7 +705,11 @@ def signup(request):
     next_url = request.GET.get("next") or request.POST.get("next")
 
     # Validate next_url to prevent open redirect vulnerabilities
-    if next_url and not next_url.startswith("/"):
+    if next_url and not url_has_allowed_host_and_scheme(
+        next_url,
+        allowed_hosts={request.get_host()},
+        require_https=request.is_secure(),
+    ):
         next_url = None
 
     # Get selected tier before form validation (not a form field, just POST data)
@@ -970,7 +975,11 @@ def complete_signup(request):
 
         # Get next URL from POST (from hidden field populated via sessionStorage)
         next_url = request.POST.get("next")
-        if next_url and next_url.startswith("/"):
+        if next_url and url_has_allowed_host_and_scheme(
+            next_url,
+            allowed_hosts={request.get_host()},
+            require_https=request.is_secure(),
+        ):
             request.session["pending_next_url"] = next_url
 
         # Mark OIDC signup as completed

--- a/docs/compliance/annual-compliance-checklist-2026.md
+++ b/docs/compliance/annual-compliance-checklist-2026.md
@@ -341,6 +341,7 @@ priority: 2
   - **Info:** F5 (f-string email builders bypass autoescaping)
   - No Critical findings; no patient data exposure at rest
   - Remediation tracked as atomic PRs with regression tests per finding
+  - **Remediation status (01/08/2026):** F1, F6, and F12 resolved; 14 findings remain open. F1 signup redirects now use Django host/scheme validation and retain the unconfirmed-email home-page flow.
 - [ ] **Tabletop Exercise (Q3)** - Cyber security simulation [Exercise Summary](/compliance/exercise-summary-2025/)
   - Based on NCSC threat intelligence
   - Test incident response procedures
@@ -615,6 +616,7 @@ priority: 2
 | :--- | :--- | :--- | :--- |
 | 08/02/2026 | 1.0 | Initial 2026 checklist created | Pending |
 | 01/08/2026 | 1.1 | Added Q3 security deep-dive review (17 findings F1–F17) to August | Pending |
+| 01/08/2026 | 1.2 | Recorded F1 open-redirect remediation and updated status to 14 open findings | Pending |
 
 ---
 

--- a/docs/compliance/risk-register.md
+++ b/docs/compliance/risk-register.md
@@ -21,7 +21,7 @@ category: dspt-5-process-reviews
 | **R04** | Insider Threat (Staff Error) | Security | 2 | 3 | **6** | Annual NHS Training; Least Privilege access; Audit logs. | {{ siro_name }} |
 | **R05** | Loss of Staff Laptop | Physical | 2 | 3 | **6** | Full Disk Encryption; Remote wipe capability; No local DB. | {{ cto_name }} |
 | **R06** | Supply Chain: GoCardless Breach | Financial | 1 | 3 | **3** | No banking data stored locally; Rely on provider PCI-DSS. | {{ siro_name }} |
-| **R07** | Application-Layer Vulnerabilities (Aug 2026 review) | Security | 2 | 4 | **8** | 17 findings (F1–F17) identified in static review: 2 High (recovery bypass, SVG XSS), 6 Medium, 8 Low, 1 Info. Remediation via atomic PRs with regression tests. See `security-review-august-2026.md`. | {{ cto_name }} |
+| **R07** | Application-Layer Vulnerabilities (Aug 2026 review) | Security | 2 | 4 | **8** | 17 findings (F1–F17) identified in static review: 2 High, 6 Medium, 8 Low, 1 Info. F1, F6, and F12 resolved on 01/08/2026 with regression tests; 14 findings remain open. Continue remediation via atomic PRs. See `security-review-august-2026.md`. | {{ cto_name }} |
 
 ## Risk Review Frequency
 

--- a/docs/compliance/security-review-august-2026.md
+++ b/docs/compliance/security-review-august-2026.md
@@ -9,7 +9,7 @@ category: dspt-6-incidents
 - **Reviewer:** CTO (with AI-assisted static review)
 - **Scope:** Full static security review of the CheckTick platform covering authentication and redirect flows, email rendering, settings hardening, DRF defaults, HashiCorp Vault integration, LLM (AI survey generator + translation), the public REST API, OIDC SSO, user-uploaded icons and survey images, user/organisation management, billing webhooks, and styling/theme CSS.
 - **Method:** Static source review of `checktick_app/core/views.py`, `checktick_app/core/email_utils.py`, `checktick_app/core/oidc_views.py`, `checktick_app/core/views_billing.py`, `checktick_app/core/theme_utils.py`, `checktick_app/core/models.py`, `checktick_app/surveys/views.py`, `checktick_app/surveys/vault_client.py`, `checktick_app/surveys/llm_client.py`, `checktick_app/surveys/models.py`, `checktick_app/api/authentication.py`, `checktick_app/api/views.py`, `checktick_app/settings.py`, and the relevant templates. Cross-referenced against the documented security model in `docs/vault.md`, `docs/llm-security.md`, `docs/api.md`, and `docs/security-overview.md`.
-- **Status:** 🔶 Remediation in progress — F6 and F12 resolved; 15 findings remain open
+- **Status:** 🔶 Remediation in progress — F1, F6, and F12 resolved; 14 findings remain open
 
 ---
 
@@ -21,7 +21,7 @@ This consolidated review identifies **17 findings (F1–F17)**: 2 High, 6 Medium
 | :--- | :--- | :--- | :--- | :--- |
 | **F6** | **High** | Vault / Recovery | Web recovery console bypasses Shamir custodian-share control | Resolved 01/08/2026 |
 | **F12** | **High** | Survey images | SVG upload → stored XSS via direct `/media/` access | Resolved 01/08/2026 |
-| F1 | Medium | Auth / Redirects | Open redirect via protocol-relative `next` URLs | Open |
+| F1 | Medium | Auth / Redirects | Open redirect via protocol-relative `next` URLs | Resolved 01/08/2026 |
 | F2 | Medium | Email | HTML injection into team/org invitation emails | Open |
 | F7 | Medium | LLM | Debug dump writes full LLM payloads to world-readable `/tmp` | Open |
 | F8 | Medium | API | `DataSetViewSet` permission class inconsistent with anonymous access | Open |
@@ -37,7 +37,7 @@ This consolidated review identifies **17 findings (F1–F17)**: 2 High, 6 Medium
 | F17 | Low | OIDC | Runtime mutation of global settings in callback view (thread-safety) | Open |
 | F5 | Info | Email | F-string email builders bypass template autoescaping | Open |
 
-**Priority for next patch:** F1, F2, F7, F8, F13, F15, F16, F17. F3, F4, F9, F10, F11, F14 are lower-urgency hardening/operational items. F6 and F12 were resolved on 1 August 2026.
+**Priority for next patch:** F2, F7, F8, F13, F15, F16, F17. F3, F4, F9, F10, F11, F14 are lower-urgency hardening/operational items. F1, F6, and F12 were resolved on 1 August 2026.
 
 ---
 
@@ -209,6 +209,8 @@ if next_url and not url_has_allowed_host_and_scheme(
 Apply the same check in both `signup` (L707) and `complete_signup` (L973). The `complete_signup` path stores `next` from POST (hidden field populated via `sessionStorage`), so it inherits the same weakness.
 
 **Regression risk:** Low. Legitimate relative `next` URLs (e.g. `/surveys/`) continue to pass; only protocol-relative and absolute-URL values are rejected.
+
+**Resolution (1 August 2026):** Both signup entry points now validate `next` with Django's `url_has_allowed_host_and_scheme`, restricted to the current host and requiring HTTPS when the request is secure. Protocol-relative, backslash-normalised, and external absolute URLs are rejected, while local relative paths continue to work. Regression tests cover both the email-confirmation and OIDC signup-completion flows.
 
 ---
 

--- a/docs/compliance/security-review-log.md
+++ b/docs/compliance/security-review-log.md
@@ -11,6 +11,7 @@ category: dspt-5-process-reviews
 | 2026-01-03 | {{ siro_name }} | Production Ingress Rules | Confirmed no temp rules from Dec deployment. | Clean |
 | 2026-08-01 | {{ cto_name }} | Application-layer static security review (full codebase) | Deep-dive review of auth/redirects, email rendering, settings, Vault, LLM, API, OIDC, icon uploads, billing, styling. 17 findings (F1–F17): 2 High, 6 Medium, 8 Low, 1 Info. Documented in `security-review-august-2026.md`. Remediation via atomic PRs. | Findings open |
 | 2026-08-01 | {{ cto_name }} | High findings F6 and F12 remediation | Removed web recovery execution and enforced 3-of-4-share CLI recovery for F6. Removed SVG survey-image uploads for F12, rejected animated raster variants, passed focused regression tests, and audited production media (0 SVG records; 0 SVG files). | F6/F12 closed; 15 findings open |
+| 2026-08-01 | {{ cto_name }} | Medium finding F1 remediation — signup open redirect | Replaced slash-prefix validation in standard and OIDC signup-completion flows with Django host/scheme validation. Regression coverage rejects protocol-relative, backslash-normalised, and external URLs; confirms local redirects remain valid; and verifies unconfirmed signup still redirects home with the confirmation notice. Full non-accessibility suite passed (1,765 tests); lint passed. | F1 closed; 14 findings open |
 | | | | | |
 
 ## Audit Procedure:

--- a/docs/compliance/vulnerability-patch-log.md
+++ b/docs/compliance/vulnerability-patch-log.md
@@ -34,7 +34,7 @@ A full static security review of the CheckTick codebase was performed on 01/08/2
 | :--- | :--- | :--- | :--- |
 | F6 | High | Web recovery console bypasses Shamir custodian-share control | Resolved 01/08/2026 — NM-02 closed |
 | F12 | High | SVG upload → stored XSS via direct `/media/` access | Resolved 01/08/2026 — NM-03 closed |
-| F1 | Medium | Open redirect via protocol-relative `next` URLs | Open |
+| F1 | Medium | Open redirect via protocol-relative `next` URLs | Resolved 01/08/2026 — Django host/scheme validation and regression tests |
 | F2 | Medium | HTML injection into team/org invitation emails | Open |
 | F7 | Medium | LLM debug dump writes full payloads to world-readable `/tmp` | Open |
 | F8 | Medium | `DataSetViewSet` permission class inconsistent with anonymous access | Open |
@@ -50,7 +50,7 @@ A full static security review of the CheckTick codebase was performed on 01/08/2
 | F17 | Low | Runtime mutation of global settings in OIDC callback view (thread-safety) | Open |
 | F5 | Info | F-string email builders bypass template autoescaping | Open |
 
-No Critical findings. No patient data exposure at rest. The two High findings (F6, F12) are recorded as resolved near-misses NM-02 and NM-03 in the Incident & Near-Miss Log. F12 remediation removed SVG upload support, added regression coverage, and confirmed through a production audit that no legacy SVG media existed.
+No Critical findings. No patient data exposure at rest. The two High findings (F6, F12) are recorded as resolved near-misses NM-02 and NM-03 in the Incident & Near-Miss Log. F12 remediation removed SVG upload support, added regression coverage, and confirmed through a production audit that no legacy SVG media existed. F1 remediation replaced slash-prefix checks with Django's `url_has_allowed_host_and_scheme`, constrained redirects to the current host, and requires HTTPS when the request is secure. Regression tests confirm protocol-relative, backslash-normalised, and external URLs are rejected while valid local redirects are preserved; successful signup still marks the email unconfirmed, redirects to the home page, and displays the confirmation notice.
 
 ### Previously Active Exceptions (Now Resolved - January 2025)
 

--- a/docs/security-overview.md
+++ b/docs/security-overview.md
@@ -65,6 +65,12 @@ Each action is verified against the user's role at the appropriate level.
 - Token refresh requires valid refresh token
 - API endpoints enforce same permissions as web UI
 
+#### Safe Signup Redirects
+
+User-controlled `next` values in the password and OIDC signup-completion flows are validated with Django's `url_has_allowed_host_and_scheme`. Redirects are restricted to the current host and must use HTTPS when the incoming request is secure. Protocol-relative, backslash-normalised, and external destinations are rejected. Valid local destinations are retained for use after account setup or email confirmation; an unconfirmed password signup still redirects to the home page and displays the email-confirmation notice.
+
+Regression tests cover accepted and rejected destinations and the unconfirmed-email flow. See F1 in `docs/compliance/security-review-august-2026.md` for the remediation record. The separate OIDC login-entry redirect is tracked as F10.
+
 **Related Documentation**:
 
 - [Authentication & Permissions](/docs/authentication-and-permissions/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "checktick"
-version = "0.8.1"
+version = "0.8.2"
 description = "Secure, server-rendered survey platform for medical audit and research"
 authors = ["CheckTick Maintainers <simon@eatyourpeas.co.uk>"]
 readme = "README.md"

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -124,7 +124,18 @@ def test_signup_only_stores_safe_post_confirmation_redirects(
     )
 
     assert response.status_code == 302
+    assert response["Location"] == reverse("core:home")
     assert client.session.get("post_confirmation_redirect") == expected_redirect
+
+    user = get_user_model().objects.get(email="redirect-test@example.com")
+    assert user.profile.email_confirmed is False
+
+    home_response = client.get(response["Location"])
+    assert home_response.status_code == 200
+    assert (
+        b"Please check your email to confirm your account before accessing features."
+        in home_response.content
+    )
 
 
 @pytest.mark.django_db

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -90,6 +90,78 @@ def test_signup_as_org_creates_org_and_shows_on_profile(client):
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("next_url", "expected_redirect"),
+    [
+        ("//evil.example/phish", None),
+        ("/\\evil.example/phish", None),
+        ("https://evil.example/phish", None),
+        ("/surveys/", "/surveys/"),
+    ],
+)
+def test_signup_only_stores_safe_post_confirmation_redirects(
+    client, monkeypatch, next_url, expected_redirect
+):
+    """Signup must reject protocol-relative and external redirect targets."""
+    monkeypatch.setattr(
+        "checktick_app.core.views.EmailConfirmationManager.send_confirmation_email",
+        lambda user, request: (None, True, None),
+    )
+    monkeypatch.setattr(
+        "checktick_app.core.email_utils.send_welcome_email", lambda user: True
+    )
+
+    response = client.post(
+        reverse("core:signup"),
+        data={
+            "email": "redirect-test@example.com",
+            "email_confirm": "redirect-test@example.com",
+            "password1": TEST_PASSWORD,
+            "password2": TEST_PASSWORD,
+            "account_type": "simple",
+            "next": next_url,
+        },
+    )
+
+    assert response.status_code == 302
+    assert client.session.get("post_confirmation_redirect") == expected_redirect
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("next_url", "expected_location"),
+    [
+        ("//evil.example/phish", reverse("surveys:list")),
+        ("/\\evil.example/phish", reverse("surveys:list")),
+        ("https://evil.example/phish", reverse("surveys:list")),
+        ("/surveys/", "/surveys/"),
+    ],
+)
+def test_complete_signup_only_redirects_to_safe_urls(
+    client, next_url, expected_location
+):
+    """OIDC signup completion must not redirect to an attacker-controlled host."""
+    user = get_user_model().objects.create_user(
+        username="redirect-oidc@example.com",
+        email="redirect-oidc@example.com",
+        password=TEST_PASSWORD,
+    )
+    UserOIDC.objects.create(user=user, signup_completed=False)
+    client.login(username=user.username, password=TEST_PASSWORD)
+    session = client.session
+    session["needs_signup_completion"] = True
+    session.save()
+
+    response = client.post(
+        reverse("core:complete_signup"),
+        data={"account_type": "simple", "next": next_url},
+    )
+
+    assert response.status_code == 302
+    assert response["Location"] == expected_location
+
+
+@pytest.mark.django_db
 def test_signup_as_simple_user(client):
     """Test that signing up as a simple user doesn't create an organization."""
     email = "simpleuser@example.com"


### PR DESCRIPTION
# Fix for F1

- `docs/compliance/vulnerability-patch-log.md`
  - Marked F1 resolved.
  - Recorded the implementation and regression evidence.
- `docs/compliance/security-review-log.md`
  - Added an audit entry showing F1 closed and 14 findings remaining.
- `docs/compliance/risk-register.md`
  - Updated R07 remediation status.
- `docs/compliance/annual-compliance-checklist-2026.md`
  - Added the current remediation status and version-history entry.
- `docs/compliance/security-review-august-2026.md`
  - Already updated with the resolution details and corrected counts.
- `docs/security-overview.md`
  - Added a “Safe Signup Redirects” control.
  - Explicitly distinguishes resolved F1 from still-open F10.

There is no `security-vulnerability-log` file; the repository’s canonical record is `docs/compliance/vulnerability-patch-log.md`.

Validation:

- `s/lint`: passed
- `git diff --check`: passed
- Previous full non-accessibility suite: **1,765 passed**