### PR TITLE
security/F2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
  <a href="https://github.com/eatyourpeas/checktick/releases">
-  <img alt="Version" src="https://img.shields.io/badge/version-0.8.2-5fcfdd?style=flat-square">
+  <img alt="Version" src="https://img.shields.io/badge/version-0.8.3-5fcfdd?style=flat-square">
  </a>
  <a href="https://github.com/eatyourpeas/checktick/blob/main/LICENSE">
   <img alt="GitHub License" src="https://img.shields.io/github/license/eatyourpeas/checktick?style=flat-square&color=5fcfdd">

--- a/checktick_app/core/email_utils.py
+++ b/checktick_app/core/email_utils.py
@@ -14,7 +14,7 @@ from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from django.template import TemplateDoesNotExist
 from django.template.loader import render_to_string
-from django.utils.html import strip_tags
+from django.utils.html import escape, strip_tags
 import markdown
 
 
@@ -2142,18 +2142,30 @@ def send_team_invitation_email(
             },
         )
     except TemplateDoesNotExist:
-        org_line = f"as part of **{organization_name}** " if organization_name else ""
-        markdown_content = f"""## You're Invited to Join {team.name}
+        safe_team_name = escape(team.name)
+        safe_organization_name = escape(organization_name) if organization_name else ""
+        safe_invited_by_name = escape(invited_by.get_full_name() or invited_by.username)
+        safe_invited_by_email = escape(invited_by.email)
+        safe_role_display = escape(role_display)
+        safe_signup_link = escape(signup_link)
+        safe_to_email = escape(to_email)
+        safe_brand_title = escape(branding["title"])
+        org_line = (
+            f"as part of **{safe_organization_name}** "
+            if safe_organization_name
+            else ""
+        )
+        markdown_content = f"""## You're Invited to Join {safe_team_name}
 
 Hi there,
 
-**{invited_by.get_full_name() or invited_by.username}** has invited you to join their team on {branding["title"]}.
+**{safe_invited_by_name}** has invited you to join their team on {safe_brand_title}.
 
 ### Invitation Details
 
-- **Team:** {team.name}
-- **Your Role:** {role_display}
-- **Invited by:** {invited_by.get_full_name() or invited_by.username} ({invited_by.email})
+- **Team:** {safe_team_name}
+- **Your Role:** {safe_role_display}
+- **Invited by:** {safe_invited_by_name} ({safe_invited_by_email})
 
 {org_line}
 
@@ -2161,28 +2173,28 @@ Hi there,
 
 To accept this invitation and join the team, create your account:
 
-[**Create Account**]({signup_link})
+[**Create Account**]({safe_signup_link})
 
 Or copy and paste this URL:
 
 ```
-{signup_link}
+{safe_signup_link}
 ```
 
-Once you create your account with **{to_email}**, you'll automatically be added to the team.
+Once you create your account with **{safe_to_email}**, you'll automatically be added to the team.
 
 ### What You'll Be Able to Do
 
-As a **{role_display}**, you'll be able to:
+As a **{safe_role_display}**, you'll be able to:
 {"- Manage team settings and members" if role == "admin" else ""}
 {"- Create and edit surveys" if role in ("admin", "creator") else ""}
 - View team surveys and data
 
 ---
 
-If you have any questions, please contact {invited_by.email}.
+If you have any questions, please contact {safe_invited_by_email}.
 
-The {branding["title"]} Team
+The {safe_brand_title} Team
 """
 
     return send_branded_email(
@@ -2244,35 +2256,42 @@ def send_org_invitation_email(
             },
         )
     except TemplateDoesNotExist:
-        markdown_content = f"""## You're Invited to Join {organization.name}
+        safe_organization_name = escape(organization.name)
+        safe_invited_by_name = escape(invited_by.get_full_name() or invited_by.username)
+        safe_invited_by_email = escape(invited_by.email)
+        safe_role_display = escape(role_display)
+        safe_signup_link = escape(signup_link)
+        safe_to_email = escape(to_email)
+        safe_brand_title = escape(branding["title"])
+        markdown_content = f"""## You're Invited to Join {safe_organization_name}
 
 Hi there,
 
-**{invited_by.get_full_name() or invited_by.username}** has invited you to join their organization on {branding["title"]}.
+**{safe_invited_by_name}** has invited you to join their organization on {safe_brand_title}.
 
 ### Invitation Details
 
-- **Organization:** {organization.name}
-- **Your Role:** {role_display}
-- **Invited by:** {invited_by.get_full_name() or invited_by.username} ({invited_by.email})
+- **Organization:** {safe_organization_name}
+- **Your Role:** {safe_role_display}
+- **Invited by:** {safe_invited_by_name} ({safe_invited_by_email})
 
 ### Get Started
 
 To accept this invitation and join the organization, create your account:
 
-[**Create Account**]({signup_link})
+[**Create Account**]({safe_signup_link})
 
 Or copy and paste this URL:
 
 ```
-{signup_link}
+{safe_signup_link}
 ```
 
-Once you create your account with **{to_email}**, you'll automatically be added to the organization.
+Once you create your account with **{safe_to_email}**, you'll automatically be added to the organization.
 
 ### What You'll Be Able to Do
 
-As a **{role_display}**, you'll be able to:
+As a **{safe_role_display}**, you'll be able to:
 {"- Manage organization settings, teams, and members" if role == "admin" else ""}
 {"- Create and edit surveys across the organization" if role in ("admin", "creator") else ""}
 - View organization surveys and data
@@ -2280,9 +2299,9 @@ As a **{role_display}**, you'll be able to:
 
 ---
 
-If you have any questions, please contact {invited_by.email}.
+If you have any questions, please contact {safe_invited_by_email}.
 
-The {branding["title"]} Team
+The {safe_brand_title} Team
 """
 
     return send_branded_email(

--- a/checktick_app/core/tests/test_invitation_emails.py
+++ b/checktick_app/core/tests/test_invitation_emails.py
@@ -1,0 +1,115 @@
+"""Security regression tests for team and organisation invitation emails."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.template import TemplateDoesNotExist
+import pytest
+
+from checktick_app.core.email_utils import (
+    send_org_invitation_email,
+    send_team_invitation_email,
+)
+
+MALICIOUS_NAME = '<a href="https://evil.example">Verify your account</a>'
+ESCAPED_NAME = (
+    "&lt;a href=&quot;https://evil.example&quot;&gt;Verify your account&lt;/a&gt;"
+)
+
+
+@pytest.fixture
+def branding():
+    return {
+        "title": "CheckTick Test",
+        "primary_color": "#3b82f6",
+        "font_heading": "Arial",
+        "font_body": "Arial",
+    }
+
+
+@pytest.fixture
+def invited_by():
+    return SimpleNamespace(
+        username="inviter",
+        email="inviter@example.com",
+        get_full_name=lambda: MALICIOUS_NAME,
+    )
+
+
+def _sent_html(mock_email_class):
+    return mock_email_class.return_value.attach_alternative.call_args.args[0]
+
+
+@pytest.mark.parametrize("invitation_type", ["team", "organisation"])
+def test_invitation_email_escapes_attacker_controlled_html(
+    invitation_type, branding, invited_by
+):
+    """Names controlled by an inviter must render as text, not trusted HTML."""
+    with (
+        patch(
+            "checktick_app.core.email_utils.get_platform_branding",
+            return_value=branding,
+        ),
+        patch("checktick_app.core.email_utils.EmailMultiAlternatives") as email_class,
+    ):
+        email_class.return_value.send.return_value = 1
+
+        if invitation_type == "team":
+            organization = SimpleNamespace(name=MALICIOUS_NAME)
+            team = SimpleNamespace(name=MALICIOUS_NAME, organization=organization)
+            result = send_team_invitation_email(
+                "recipient@example.com", team, "viewer", invited_by
+            )
+        else:
+            organization = SimpleNamespace(name=MALICIOUS_NAME)
+            result = send_org_invitation_email(
+                "recipient@example.com", organization, "viewer", invited_by
+            )
+
+    assert result is True
+    html = _sent_html(email_class)
+    assert MALICIOUS_NAME not in html
+    assert ESCAPED_NAME in html
+
+
+@pytest.mark.parametrize("invitation_type", ["team", "organisation"])
+def test_invitation_email_fallback_escapes_attacker_controlled_html(
+    invitation_type, branding, invited_by
+):
+    """A missing content template must not reintroduce HTML injection."""
+    captured = {}
+
+    def capture_email(**kwargs):
+        captured.update(kwargs)
+        return True
+
+    with (
+        patch(
+            "checktick_app.core.email_utils.get_platform_branding",
+            return_value=branding,
+        ),
+        patch(
+            "checktick_app.core.email_utils.render_to_string",
+            side_effect=TemplateDoesNotExist("invitation template"),
+        ),
+        patch(
+            "checktick_app.core.email_utils.send_branded_email",
+            side_effect=capture_email,
+        ),
+    ):
+        if invitation_type == "team":
+            organization = SimpleNamespace(name=MALICIOUS_NAME)
+            team = SimpleNamespace(name=MALICIOUS_NAME, organization=organization)
+            result = send_team_invitation_email(
+                "recipient@example.com", team, "viewer", invited_by
+            )
+        else:
+            organization = SimpleNamespace(name=MALICIOUS_NAME)
+            result = send_org_invitation_email(
+                "recipient@example.com", organization, "viewer", invited_by
+            )
+
+    assert result is True
+    markdown_content = captured["markdown_content"]
+    assert MALICIOUS_NAME not in markdown_content
+    assert ESCAPED_NAME in markdown_content

--- a/checktick_app/templates/emails/org_invitation.md
+++ b/checktick_app/templates/emails/org_invitation.md
@@ -1,0 +1,39 @@
+## You're Invited to Join {{ org_name }}
+
+Hi there,
+
+**{{ invited_by_name }}** has invited you to join their organisation on {{ brand_title }}.
+
+### Invitation Details
+
+- **Organisation:** {{ org_name }}
+- **Your Role:** {{ role_display }}
+- **Invited by:** {{ invited_by_name }} ({{ invited_by_email }})
+
+### Get Started
+
+To accept this invitation and join the organisation, create your account:
+
+[**Create Account**]({{ signup_link }})
+
+Or copy and paste this URL:
+
+```
+{{ signup_link }}
+```
+
+Once you create your account, you'll automatically be added to the organisation.
+
+### What You'll Be Able to Do
+
+As a **{{ role_display }}**, you'll be able to:
+{% if role == "admin" %}- Manage organisation settings, teams, and members{% endif %}
+{% if role == "admin" or role == "creator" %}- Create and edit surveys across the organisation{% endif %}
+- View organisation surveys and data
+- Collaborate with team members
+
+---
+
+If you have any questions, please contact {{ invited_by_email }}.
+
+The {{ brand_title }} Team

--- a/checktick_app/templates/emails/team_invitation.md
+++ b/checktick_app/templates/emails/team_invitation.md
@@ -1,0 +1,40 @@
+## You're Invited to Join {{ team_name }}
+
+Hi there,
+
+**{{ invited_by_name }}** has invited you to join their team on {{ brand_title }}.
+
+### Invitation Details
+
+- **Team:** {{ team_name }}
+- **Your Role:** {{ role_display }}
+- **Invited by:** {{ invited_by_name }} ({{ invited_by_email }})
+
+{% if organization_name %}This team is part of **{{ organization_name }}**.{% endif %}
+
+### Get Started
+
+To accept this invitation and join the team, create your account:
+
+[**Create Account**]({{ signup_link }})
+
+Or copy and paste this URL:
+
+```
+{{ signup_link }}
+```
+
+Once you create your account, you'll automatically be added to the team.
+
+### What You'll Be Able to Do
+
+As a **{{ role_display }}**, you'll be able to:
+{% if role == "admin" %}- Manage team settings and members{% endif %}
+{% if role == "admin" or role == "creator" %}- Create and edit surveys{% endif %}
+- View team surveys and data
+
+---
+
+If you have any questions, please contact {{ invited_by_email }}.
+
+The {{ brand_title }} Team

--- a/docs/compliance/annual-compliance-checklist-2026.md
+++ b/docs/compliance/annual-compliance-checklist-2026.md
@@ -341,7 +341,7 @@ priority: 2
   - **Info:** F5 (f-string email builders bypass autoescaping)
   - No Critical findings; no patient data exposure at rest
   - Remediation tracked as atomic PRs with regression tests per finding
-  - **Remediation status (01/08/2026):** F1, F6, and F12 resolved; 14 findings remain open. F1 signup redirects now use Django host/scheme validation and retain the unconfirmed-email home-page flow.
+  - **Remediation status (01/08/2026):** F1, F2, F6, and F12 resolved; 13 findings remain open. F1 signup redirects now use Django host/scheme validation and retain the unconfirmed-email home-page flow. F2 team and organisation invitation emails now use autoescaped Markdown templates plus explicitly escaped template-missing fallbacks, with regression coverage for both paths.
 - [ ] **Tabletop Exercise (Q3)** - Cyber security simulation [Exercise Summary](/compliance/exercise-summary-2025/)
   - Based on NCSC threat intelligence
   - Test incident response procedures

--- a/docs/compliance/risk-register.md
+++ b/docs/compliance/risk-register.md
@@ -21,7 +21,7 @@ category: dspt-5-process-reviews
 | **R04** | Insider Threat (Staff Error) | Security | 2 | 3 | **6** | Annual NHS Training; Least Privilege access; Audit logs. | {{ siro_name }} |
 | **R05** | Loss of Staff Laptop | Physical | 2 | 3 | **6** | Full Disk Encryption; Remote wipe capability; No local DB. | {{ cto_name }} |
 | **R06** | Supply Chain: GoCardless Breach | Financial | 1 | 3 | **3** | No banking data stored locally; Rely on provider PCI-DSS. | {{ siro_name }} |
-| **R07** | Application-Layer Vulnerabilities (Aug 2026 review) | Security | 2 | 4 | **8** | 17 findings (F1–F17) identified in static review: 2 High, 6 Medium, 8 Low, 1 Info. F1, F6, and F12 resolved on 01/08/2026 with regression tests; 14 findings remain open. Continue remediation via atomic PRs. See `security-review-august-2026.md`. | {{ cto_name }} |
+| **R07** | Application-Layer Vulnerabilities (Aug 2026 review) | Security | 2 | 4 | **8** | 17 findings (F1–F17) identified in static review: 2 High, 6 Medium, 8 Low, 1 Info. F1, F2, F6, and F12 resolved on 01/08/2026 with regression tests; 13 findings remain open. Continue remediation via atomic PRs. See `security-review-august-2026.md`. | {{ cto_name }} |
 
 ## Risk Review Frequency
 

--- a/docs/compliance/security-review-august-2026.md
+++ b/docs/compliance/security-review-august-2026.md
@@ -9,7 +9,7 @@ category: dspt-6-incidents
 - **Reviewer:** CTO (with AI-assisted static review)
 - **Scope:** Full static security review of the CheckTick platform covering authentication and redirect flows, email rendering, settings hardening, DRF defaults, HashiCorp Vault integration, LLM (AI survey generator + translation), the public REST API, OIDC SSO, user-uploaded icons and survey images, user/organisation management, billing webhooks, and styling/theme CSS.
 - **Method:** Static source review of `checktick_app/core/views.py`, `checktick_app/core/email_utils.py`, `checktick_app/core/oidc_views.py`, `checktick_app/core/views_billing.py`, `checktick_app/core/theme_utils.py`, `checktick_app/core/models.py`, `checktick_app/surveys/views.py`, `checktick_app/surveys/vault_client.py`, `checktick_app/surveys/llm_client.py`, `checktick_app/surveys/models.py`, `checktick_app/api/authentication.py`, `checktick_app/api/views.py`, `checktick_app/settings.py`, and the relevant templates. Cross-referenced against the documented security model in `docs/vault.md`, `docs/llm-security.md`, `docs/api.md`, and `docs/security-overview.md`.
-- **Status:** 🔶 Remediation in progress — F1, F6, and F12 resolved; 14 findings remain open
+- **Status:** 🔶 Remediation in progress — F1, F2, F6, and F12 resolved; 13 findings remain open
 
 ---
 
@@ -22,7 +22,7 @@ This consolidated review identifies **17 findings (F1–F17)**: 2 High, 6 Medium
 | **F6** | **High** | Vault / Recovery | Web recovery console bypasses Shamir custodian-share control | Resolved 01/08/2026 |
 | **F12** | **High** | Survey images | SVG upload → stored XSS via direct `/media/` access | Resolved 01/08/2026 |
 | F1 | Medium | Auth / Redirects | Open redirect via protocol-relative `next` URLs | Resolved 01/08/2026 |
-| F2 | Medium | Email | HTML injection into team/org invitation emails | Open |
+| F2 | Medium | Email | HTML injection into team/org invitation emails | Resolved 01/08/2026 |
 | F7 | Medium | LLM | Debug dump writes full LLM payloads to world-readable `/tmp` | Open |
 | F8 | Medium | API | `DataSetViewSet` permission class inconsistent with anonymous access | Open |
 | F13 | Medium | Styling | Survey `icon_url` accepts `javascript:` and `data:` URIs | Open |
@@ -37,7 +37,7 @@ This consolidated review identifies **17 findings (F1–F17)**: 2 High, 6 Medium
 | F17 | Low | OIDC | Runtime mutation of global settings in callback view (thread-safety) | Open |
 | F5 | Info | Email | F-string email builders bypass template autoescaping | Open |
 
-**Priority for next patch:** F2, F7, F8, F13, F15, F16, F17. F3, F4, F9, F10, F11, F14 are lower-urgency hardening/operational items. F1, F6, and F12 were resolved on 1 August 2026.
+**Priority for next patch:** F7, F8, F13, F15, F16, F17. F3, F4, F9, F10, F11, F14 are lower-urgency hardening/operational items. F1, F2, F6, and F12 were resolved on 1 August 2026.
 
 ---
 
@@ -245,6 +245,8 @@ Any authenticated user can create a team (or organisation) named, for example:
 2. **Escape the fallback path.** In the `except TemplateDoesNotExist` branches, wrap interpolated user-controlled values with `django.utils.html.escape()`, or — preferably — sanitise the `markdown_to_html()` output with `nh3` before it reaches `content|safe`. This closes the class even if a future template is deleted.
 
 **Regression risk:** Low. Adding templates changes only the rendering source; escaping the fallback changes behaviour only for inputs containing `<`, `>`, `&` — which are not legitimate in team/org names or display names.
+
+**Resolution (1 August 2026):** Added the missing `emails/team_invitation.md` and `emails/org_invitation.md` templates so Django autoescapes team, organisation, and inviter names before Markdown conversion. The `TemplateDoesNotExist` fallbacks now explicitly escape every interpolated dynamic value as defence in depth. Regression tests verify that attacker-controlled anchor markup is rendered as text in both invitation types and remains escaped when the content template is unavailable.
 
 ---
 

--- a/docs/compliance/vulnerability-patch-log.md
+++ b/docs/compliance/vulnerability-patch-log.md
@@ -35,7 +35,7 @@ A full static security review of the CheckTick codebase was performed on 01/08/2
 | F6 | High | Web recovery console bypasses Shamir custodian-share control | Resolved 01/08/2026 — NM-02 closed |
 | F12 | High | SVG upload → stored XSS via direct `/media/` access | Resolved 01/08/2026 — NM-03 closed |
 | F1 | Medium | Open redirect via protocol-relative `next` URLs | Resolved 01/08/2026 — Django host/scheme validation and regression tests |
-| F2 | Medium | HTML injection into team/org invitation emails | Open |
+| F2 | Medium | HTML injection into team/org invitation emails | Resolved 01/08/2026 — autoescaped templates, escaped fallbacks, and regression tests |
 | F7 | Medium | LLM debug dump writes full payloads to world-readable `/tmp` | Open |
 | F8 | Medium | `DataSetViewSet` permission class inconsistent with anonymous access | Open |
 | F13 | Medium | Survey `icon_url` accepts `javascript:` and `data:` URIs | Open |
@@ -50,7 +50,7 @@ A full static security review of the CheckTick codebase was performed on 01/08/2
 | F17 | Low | Runtime mutation of global settings in OIDC callback view (thread-safety) | Open |
 | F5 | Info | F-string email builders bypass template autoescaping | Open |
 
-No Critical findings. No patient data exposure at rest. The two High findings (F6, F12) are recorded as resolved near-misses NM-02 and NM-03 in the Incident & Near-Miss Log. F12 remediation removed SVG upload support, added regression coverage, and confirmed through a production audit that no legacy SVG media existed. F1 remediation replaced slash-prefix checks with Django's `url_has_allowed_host_and_scheme`, constrained redirects to the current host, and requires HTTPS when the request is secure. Regression tests confirm protocol-relative, backslash-normalised, and external URLs are rejected while valid local redirects are preserved; successful signup still marks the email unconfirmed, redirects to the home page, and displays the confirmation notice.
+No Critical findings. No patient data exposure at rest. The two High findings (F6, F12) are recorded as resolved near-misses NM-02 and NM-03 in the Incident & Near-Miss Log. F12 remediation removed SVG upload support, added regression coverage, and confirmed through a production audit that no legacy SVG media existed. F1 remediation replaced slash-prefix checks with Django's `url_has_allowed_host_and_scheme`, constrained redirects to the current host, and requires HTTPS when the request is secure. Regression tests confirm protocol-relative, backslash-normalised, and external URLs are rejected while valid local redirects are preserved; successful signup still marks the email unconfirmed, redirects to the home page, and displays the confirmation notice. F2 remediation added the missing team and organisation invitation Markdown templates, restoring Django autoescaping before Markdown-to-HTML conversion, and explicitly escapes all dynamic values in the template-missing fallbacks. Regression tests cover both invitation types and both normal and fallback rendering paths.
 
 ### Previously Active Exceptions (Now Resolved - January 2025)
 

--- a/docs/email-notifications.md
+++ b/docs/email-notifications.md
@@ -229,7 +229,8 @@ Each email has two components:
 | `survey_deleted.md` | Survey deletion confirmation | `user.username`, `survey_name`, `survey_slug` |
 | `authenticated_invite_existing_user.md` | Existing-user survey invite | `recipient_name`, `inviter_name`, `survey_name`, `dashboard_url` |
 | `authenticated_invite_new_user.md` | New-user survey invite | `recipient_name`, `inviter_name`, `survey_name`, `register_url` |
-| `team_invitation.md` | Team/org invitation | `recipient_name`, `inviter_name`, `team_name`, `invitation_link` |
+| `team_invitation.md` | Team invitation | `team_name`, `role`, `role_display`, `invited_by_name`, `invited_by_email`, `signup_link`, `organization_name`, `brand_title` |
+| `org_invitation.md` | Organisation invitation | `org_name`, `role`, `role_display`, `invited_by_name`, `invited_by_email`, `signup_link`, `brand_title` |
 | `subscription_created.md` | Subscription started | `user_name`, `plan_name`, `next_payment_date`, `amount`, `currency` |
 | `subscription_cancelled.md` | Subscription cancelled | `user_name`, `plan_name`, `cancelled_at`, `final_access_date` |
 | `subscription_expired.md` | Subscription expired | `user_name`, `expired_at`, `reactivation_url` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "checktick"
-version = "0.8.2"
+version = "0.8.3"
 description = "Secure, server-rendered survey platform for medical audit and research"
 authors = ["CheckTick Maintainers <simon@eatyourpeas.co.uk>"]
 readme = "README.md"


### PR DESCRIPTION
Implemented and documented the F2 remediation.

### Changes

- Added regression tests in `checktick_app/core/tests/test_invitation_emails.py` covering:
  - Team and organisation invitations.
  - Normal template rendering.
  - `TemplateDoesNotExist` fallback rendering.
  - Attacker-controlled anchor markup in organisation/team and inviter names.
- Added autoescaped Markdown templates:
  - `checktick_app/templates/emails/team_invitation.md`
  - `checktick_app/templates/emails/org_invitation.md`
- Hardened fallback rendering in `checktick_app/core/email_utils.py` by escaping every dynamic value before Markdown conversion.

### Test progression

- Before remediation: **4 failed**, confirming raw attacker-controlled HTML reached invitation emails.
- After remediation: **4 passed**.
- Full non-accessibility suite: **1769 passed**, with six existing naive-datetime warnings.
- `s/lint`: passed after automatically formatting the changed Python files.
- Editor diagnostics and `git diff --check`: clean.

### Documentation updated

- `docs/compliance/security-review-august-2026.md`
- `docs/compliance/vulnerability-patch-log.md`
- `docs/compliance/annual-compliance-checklist-2026.md`
- `docs/compliance/risk-register.md`
- `docs/email-notifications.md`

F2 is now recorded as resolved on 1 August 2026, with **13 findings remaining open**.