### PR TITLE
Security/f7 llm tmp

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -220,3 +220,16 @@ VAULT_SECRET_ID=your-vault-secret-id-from-setup
 #   Share 2 → Admin 2's password manager
 #   Share 3 → Physical safe
 #   Share 4 → Encrypted cloud backup (spare)
+
+# =============================
+# LLM
+# =============================
+# LLM_API_KEY="################"
+LLM_URL="https://url.../ollama/v1/chat/completions"
+LLM_AUTH_TYPE=apim # this is the default, so optional
+LLM_ENABLED=True
+LLM_TIMEOUT=30
+LLM_MAX_RETRIES=2
+LLM_TEMPERATURE=0.2
+LLM_MODEL=qwen3.5:35b
+LLM_DEBUG_DUMP=1

--- a/.env.selfhost
+++ b/.env.selfhost
@@ -145,6 +145,14 @@ EXTERNAL_DATASET_API_KEY=your-rcpch-api-key-here
 # Authentication type: 'apim' for Azure API Management (Ocp-Apim-Subscription-Key header)
 #                      'bearer' for standard OpenAI (Authorization: Bearer header)
 # LLM_AUTH_TYPE=apim
+#
+# Optional LLM debug dump (development only). When set, the LLM client writes
+# response diagnostics to <BASE_DIR>/logs/llm/ with mode 0o600 and prunes files
+# older than 24h. The outgoing messages payload is never written to disk.
+# In production (ENVIRONMENT=production) this is a no-op unless LLM_DEBUG_DUMP_INSECURE=1
+# is also set, which acknowledges that response payloads will be written to disk.
+# LLM_DEBUG_DUMP=1
+# LLM_DEBUG_DUMP_INSECURE=1
 
 # ========================
 # OPTIONAL: Billing / Pricing Configuration
@@ -166,3 +174,16 @@ EXTERNAL_DATASET_API_KEY=your-rcpch-api-key-here
 # COMPANY_NAME=Your Organisation Ltd
 # COMPANY_ADDRESS=Your Address
 # COMPANY_REGISTRATION_NUMBER=
+
+# =============================
+# LLM
+# =============================
+# LLM_API_KEY="################"
+LLM_URL="https://url.../ollama/v1/chat/completions"
+LLM_AUTH_TYPE=apim # this is the default, so optional
+LLM_ENABLED=True
+LLM_TIMEOUT=30
+LLM_MAX_RETRIES=2
+LLM_TEMPERATURE=0.2
+LLM_MODEL=qwen3.5:35b
+LLM_DEBUG_DUMP=1

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
  <a href="https://github.com/eatyourpeas/checktick/releases">
-  <img alt="Version" src="https://img.shields.io/badge/version-0.8.3-5fcfdd?style=flat-square">
+  <img alt="Version" src="https://img.shields.io/badge/version-0.8.4-5fcfdd?style=flat-square">
  </a>
  <a href="https://github.com/eatyourpeas/checktick/blob/main/LICENSE">
   <img alt="GitHub License" src="https://img.shields.io/github/license/eatyourpeas/checktick?style=flat-square&color=5fcfdd">

--- a/checktick_app/surveys/llm_client.py
+++ b/checktick_app/surveys/llm_client.py
@@ -78,9 +78,7 @@ def _write_llm_debug_dump(payload: Dict) -> None:
             pass
 
         # Prune files older than the retention window.
-        cutoff = datetime.utcnow().timestamp() - (
-            _LLM_DEBUG_DUMP_MAX_AGE_HOURS * 3600
-        )
+        cutoff = datetime.utcnow().timestamp() - (_LLM_DEBUG_DUMP_MAX_AGE_HOURS * 3600)
         for stale in dump_dir.glob("llm_response_*.json"):
             try:
                 if stale.stat().st_mtime < cutoff:
@@ -784,9 +782,7 @@ class ConversationalSurveyLLM:
                                 "timestamp": datetime.utcnow().strftime(
                                     "%Y%m%dT%H%M%SZ"
                                 ),
-                                "status_code": getattr(
-                                    response, "status_code", None
-                                ),
+                                "status_code": getattr(response, "status_code", None),
                                 "headers": (
                                     dict(response.headers)
                                     if hasattr(response, "headers")

--- a/checktick_app/surveys/llm_client.py
+++ b/checktick_app/surveys/llm_client.py
@@ -29,6 +29,87 @@ def _pick_first_key(d: Dict, keys: List[str]) -> tuple[Optional[str], Optional[s
     return None, None
 
 
+# Maximum age (hours) of LLM debug dump files retained on disk.
+_LLM_DEBUG_DUMP_MAX_AGE_HOURS = 24
+
+
+def _llm_debug_dump_enabled() -> bool:
+    """Return True if LLM debug dumps are enabled for this process.
+
+    Dumps are gated by the ``LLM_DEBUG_DUMP`` env var. In production
+    (``settings.ENVIRONMENT == "production"``) the operator must additionally
+    set ``LLM_DEBUG_DUMP_INSECURE=1`` to acknowledge that response payloads
+    will be written to disk; this prevents accidental enablement in prod.
+    """
+    if not os.environ.get("LLM_DEBUG_DUMP"):
+        return False
+    if getattr(settings, "ENVIRONMENT", "development") == "production":
+        if not os.environ.get("LLM_DEBUG_DUMP_INSECURE"):
+            return False
+    return True
+
+
+def _write_llm_debug_dump(payload: Dict) -> None:
+    """Write a redacted LLM diagnostic dump to a private, retention-bounded dir.
+
+    Security properties (addresses security review finding F7):
+
+    * Files are written under ``settings.BASE_DIR / "logs" / "llm"`` with mode
+      ``0o600`` (owner read/write only) rather than world-readable ``/tmp``.
+    * The directory is created with mode ``0o700``.
+    * Files older than 24h are pruned on each call to bound retention/disk use.
+    * The outgoing ``messages`` payload is never written — only the response
+      and metadata supplied by the caller. This keeps user-supplied prompts
+      (which may contain healthcare-adjacent content) out of the dump.
+    * In production, dumps require ``LLM_DEBUG_DUMP_INSECURE=1`` and a warning
+      is logged on each write.
+    """
+    if not _llm_debug_dump_enabled():
+        return
+    try:
+        dump_dir = Path(settings.BASE_DIR) / "logs" / "llm"
+        dump_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            dump_dir.chmod(0o700)
+        except OSError:
+            # Mode may already be correct or filesystem may not support chmod
+            # (e.g. some container overlays). Non-fatal — file mode below is
+            # the primary guard.
+            pass
+
+        # Prune files older than the retention window.
+        cutoff = datetime.utcnow().timestamp() - (
+            _LLM_DEBUG_DUMP_MAX_AGE_HOURS * 3600
+        )
+        for stale in dump_dir.glob("llm_response_*.json"):
+            try:
+                if stale.stat().st_mtime < cutoff:
+                    stale.unlink()
+            except OSError:
+                pass
+
+        now = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+        dump_id = uuid.uuid4().hex[:8]
+        filename = dump_dir / f"llm_response_{now}_{dump_id}.json"
+        with open(filename, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, ensure_ascii=False, indent=2)
+        try:
+            filename.chmod(0o600)
+        except OSError:
+            pass
+
+        if getattr(settings, "ENVIRONMENT", "development") == "production":
+            logger.warning(
+                "LLM_DEBUG_DUMP_INSECURE is enabled in production; wrote debug "
+                "dump (response only, no user prompts) to %s",
+                filename,
+            )
+        else:
+            logger.warning("Wrote LLM debug dump: %s", filename)
+    except Exception:
+        logger.exception("Failed to write LLM debug dump")
+
+
 def load_system_prompt_from_docs() -> str:
     """
     Load the system prompt from the AI survey generator documentation.
@@ -391,18 +472,14 @@ class ConversationalSurveyLLM:
                     if content.endswith("```"):
                         content = content[:-3].strip()
 
-                # Optional debug dump of full response
-                if os.environ.get("LLM_DEBUG_DUMP"):
-                    try:
-                        now = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
-                        dump_id = uuid.uuid4().hex[:8]
-                        filename = f"/tmp/llm_response_{now}_{dump_id}.json"
-                        diag = {"timestamp": now, "response": data}
-                        with open(filename, "w", encoding="utf-8") as fh:
-                            json.dump(diag, fh, ensure_ascii=False, indent=2)
-                        logger.warning("Wrote LLM debug dump: %s", filename)
-                    except Exception:
-                        logger.exception("Failed to write LLM debug dump")
+                # Optional debug dump of full response (response only, no
+                # outgoing messages — see _write_llm_debug_dump for the policy).
+                _write_llm_debug_dump(
+                    {
+                        "timestamp": datetime.utcnow().strftime("%Y%m%dT%H%M%SZ"),
+                        "response": data,
+                    }
+                )
 
                 return content
 
@@ -497,18 +574,13 @@ class ConversationalSurveyLLM:
                     if content.endswith("```"):
                         content = content[:-3].strip()
 
-                # Optional debug dump
-                if os.environ.get("LLM_DEBUG_DUMP"):
-                    try:
-                        now = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
-                        dump_id = uuid.uuid4().hex[:8]
-                        filename = f"/tmp/llm_response_{now}_{dump_id}.json"
-                        diag = {"timestamp": now, "response": data}
-                        with open(filename, "w", encoding="utf-8") as fh:
-                            json.dump(diag, fh, ensure_ascii=False, indent=2)
-                        logger.warning("Wrote LLM debug dump: %s", filename)
-                    except Exception:
-                        logger.exception("Failed to write LLM debug dump")
+                # Optional debug dump (response only, no outgoing messages).
+                _write_llm_debug_dump(
+                    {
+                        "timestamp": datetime.utcnow().strftime("%Y%m%dT%H%M%SZ"),
+                        "response": data,
+                    }
+                )
 
                 return content
 
@@ -703,39 +775,26 @@ class ConversationalSurveyLLM:
                         except Exception:
                             body = "<unreadable>"
 
-                        if os.environ.get("LLM_DEBUG_DUMP"):
-                            try:
-                                now = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
-                                dump_id = uuid.uuid4().hex[:8]
-                                filename = f"/tmp/llm_response_{now}_{dump_id}.json"
-                                diag = {
-                                    "timestamp": now,
-                                    "status_code": getattr(
-                                        response, "status_code", None
-                                    ),
-                                    "headers": (
-                                        dict(response.headers)
-                                        if hasattr(response, "headers")
-                                        else {}
-                                    ),
-                                    "body": body,
-                                    "payload_preview": (
-                                        payload_preview
-                                        if "payload_preview" in locals()
-                                        else None
-                                    ),
-                                }
-                                with open(filename, "w", encoding="utf-8") as fh:
-                                    json.dump(diag, fh, ensure_ascii=False, indent=2)
-                                logger.warning(
-                                    "Wrote full LLM HTTP response for diagnosis: %s",
-                                    filename,
-                                )
-                            except Exception as e:
-                                logger.error(
-                                    "Failed to write diagnostic LLM response file: %s",
-                                    e,
-                                )
+                        # Optionally dump full HTTP response for diagnosis.
+                        # NOTE: the outgoing payload_preview (which contains user
+                        # prompts) is intentionally omitted to comply with the
+                        # AGENTS.md logging rules. See _write_llm_debug_dump.
+                        _write_llm_debug_dump(
+                            {
+                                "timestamp": datetime.utcnow().strftime(
+                                    "%Y%m%dT%H%M%SZ"
+                                ),
+                                "status_code": getattr(
+                                    response, "status_code", None
+                                ),
+                                "headers": (
+                                    dict(response.headers)
+                                    if hasattr(response, "headers")
+                                    else {}
+                                ),
+                                "body": body,
+                            }
+                        )
 
                         logger.warning(
                             "LLM stream produced no content. HTTP %s response body (truncated): %s",

--- a/docs/compliance/security-review-august-2026.md
+++ b/docs/compliance/security-review-august-2026.md
@@ -23,7 +23,7 @@ This consolidated review identifies **17 findings (F1–F17)**: 2 High, 6 Medium
 | **F12** | **High** | Survey images | SVG upload → stored XSS via direct `/media/` access | Resolved 01/08/2026 |
 | F1 | Medium | Auth / Redirects | Open redirect via protocol-relative `next` URLs | Resolved 01/08/2026 |
 | F2 | Medium | Email | HTML injection into team/org invitation emails | Resolved 01/08/2026 |
-| F7 | Medium | LLM | Debug dump writes full LLM payloads to world-readable `/tmp` | Open |
+| F7 | Medium | LLM | Debug dump writes full LLM payloads to world-readable `/tmp` | Resolved 02/08/2026 |
 | F8 | Medium | API | `DataSetViewSet` permission class inconsistent with anonymous access | Open |
 | F13 | Medium | Styling | Survey `icon_url` accepts `javascript:` and `data:` URIs | Open |
 | F14 | Medium | Billing | Webhook has no replay protection (no timestamp/idempotency) | Open |
@@ -37,7 +37,7 @@ This consolidated review identifies **17 findings (F1–F17)**: 2 High, 6 Medium
 | F17 | Low | OIDC | Runtime mutation of global settings in callback view (thread-safety) | Open |
 | F5 | Info | Email | F-string email builders bypass template autoescaping | Open |
 
-**Priority for next patch:** F7, F8, F13, F15, F16, F17. F3, F4, F9, F10, F11, F14 are lower-urgency hardening/operational items. F1, F2, F6, and F12 were resolved on 1 August 2026.
+**Priority for next patch:** F8, F13, F15, F16, F17. F3, F4, F9, F10, F11, F14 are lower-urgency hardening/operational items. F1, F2, F6, and F12 were resolved on 1 August 2026; F7 was resolved on 2 August 2026.
 
 ---
 
@@ -250,7 +250,7 @@ Any authenticated user can create a team (or organisation) named, for example:
 
 ---
 
-## F7 — LLM debug dump writes full payloads to world-readable `/tmp` (Medium)
+## F7 — LLM debug dump writes full payloads to world-readable `/tmp` (Medium) — RESOLVED 02/08/2026
 
 **Location:** `checktick_app/surveys/llm_client.py` L393–405, L499–511, L701–718
 
@@ -288,6 +288,8 @@ If an operator enables `LLM_DEBUG_DUMP` to diagnose an LLM issue (a reasonable t
 4. Alternatively, remove the dump entirely and rely on the existing `logger.debug` calls (which already truncate to 200–1000 chars and go through the JSON formatter).
 
 **Regression risk:** Low. Debug-only path; no behavioural change when the env var is unset.
+
+**Remediation (02/08/2026):** All three inline dump sites in `checktick_app/surveys/llm_client.py` (`chat`, `chat_with_custom_system_prompt`, `chat_stream`) were replaced with calls to a single `_write_llm_debug_dump` helper. The helper writes to `settings.BASE_DIR / "logs" / "llm"` with file mode `0o600` and directory mode `0o700` (no longer `/tmp`), prunes files older than 24h on each call, omits the outgoing `messages`/`payload_preview` payload so user prompts are never written to disk, and is blocked in production (`settings.ENVIRONMENT == "production"`) unless `LLM_DEBUG_DUMP_INSECURE=1` is also set. When enabled in production, each write emits a warning log. Regression tests in `tests/test_llm_debug_dump_security.py` cover: dump disabled by default, private directory/file modes in dev, messages-omission invariant, production block without the insecure flag, production allow with the insecure flag, 24h retention pruning, and an end-to-end check that `ConversationalSurveyLLM.chat` routes through the helper. All four recommended-fix options were addressed (private path + cleanup, messages omitted, production gate with warning, and the existing `logger.debug` calls remain as the preferred diagnostic path).
 
 ---
 
@@ -849,7 +851,7 @@ The `verify_gocardless_webhook_signature` implementation (L659–700) is correct
 | F12 | High | CTO | Small (remove SVG from allowlist + production media audit) | **Resolved 01/08/2026** | SVG rejected; audit confirmed no legacy SVG media |
 | F1 | Medium | CTO | Small (swap validator in 2 sites) | Next patch | |
 | F2 | Medium | CTO | Medium (2 new templates + escape fallbacks) | Next patch | |
-| F7 | Medium | CTO | Small (relocate/redact dump) | Next patch | |
+| F7 | Medium | CTO | Small (relocate/redact dump) | **Resolved 02/08/2026** | Private `logs/llm/` dir, 0o600 files, 24h prune, messages omitted, prod gate |
 | F8 | Medium | CTO | Trivial (permission declaration + test) | Next patch | |
 | F13 | Medium | CTO | Trivial (add protocol validation) | Next patch | Bundle with F1/F10 redirect fixes |
 | F14 | Medium | CTO | Medium (idempotency table + handler audit) | Next minor | Standard webhook hygiene |
@@ -868,6 +870,7 @@ Validation for all fixes: `s/test --no-a11y` and `s/lint` per `AGENTS.md`. Speci
 - **F1, F10:** assert `//evil.com` and `/\evil.com` are rejected at signup, complete_signup, and OIDC login.
 - **F2:** assert a team name containing `<a>` is entity-escaped in the rendered email body.
 - **F6:** assert the web recovery path either redirects to the CLI or requires custodian shares, and that `settings.PLATFORM_CUSTODIAN_COMPONENT` is not read by any web-reachable code path.
+- **F7:** assert dumps are written under `settings.BASE_DIR / "logs" / "llm"` with mode `0o600`, the outgoing `messages` payload is absent from the file, dumps are blocked in production without `LLM_DEBUG_DUMP_INSECURE=1`, and files older than 24h are pruned (`tests/test_llm_debug_dump_security.py`).
 - **F8:** assert an anonymous request to `/api/datasets/` returns only global datasets and that `/api/datasets/{key}/` for a non-global dataset returns 401/404 for anonymous callers.
 - **F12:** assert script-bearing `.svg` uploads and animated variants of allowed raster formats are rejected without persistence; production audit confirmed no existing SVG media requiring cleanup.
 - **F14:** replay the same webhook twice and assert no duplicate `Payment` rows.

--- a/docs/compliance/vulnerability-patch-log.md
+++ b/docs/compliance/vulnerability-patch-log.md
@@ -9,7 +9,7 @@ category: dspt-8-unsupported-systems
 **Reviewed and Approved By:** Dr Serena Haywood (SIRO)
 **Last SIRO Review:** March 2026
 **Next Review:** June 2026
-**Last Updated:** 01 August 2026
+**Last Updated:** 02 August 2026
 
 Threat intelligence is sourced from NCSC Early Warning, GitHub Security Advisories, and OWASP and is reviewed as a standing item in our quarterly security meeting. Significant threat intelligence events are recorded in this log.
 
@@ -36,7 +36,7 @@ A full static security review of the CheckTick codebase was performed on 01/08/2
 | F12 | High | SVG upload → stored XSS via direct `/media/` access | Resolved 01/08/2026 — NM-03 closed |
 | F1 | Medium | Open redirect via protocol-relative `next` URLs | Resolved 01/08/2026 — Django host/scheme validation and regression tests |
 | F2 | Medium | HTML injection into team/org invitation emails | Resolved 01/08/2026 — autoescaped templates, escaped fallbacks, and regression tests |
-| F7 | Medium | LLM debug dump writes full payloads to world-readable `/tmp` | Open |
+| F7 | Medium | LLM debug dump writes full payloads to world-readable `/tmp` | Resolved 02/08/2026 — private, retention-bounded dump dir and regression tests |
 | F8 | Medium | `DataSetViewSet` permission class inconsistent with anonymous access | Open |
 | F13 | Medium | Survey `icon_url` accepts `javascript:` and `data:` URIs | Open |
 | F14 | Medium | Billing webhook has no replay protection (no timestamp/idempotency) | Open |
@@ -50,7 +50,7 @@ A full static security review of the CheckTick codebase was performed on 01/08/2
 | F17 | Low | Runtime mutation of global settings in OIDC callback view (thread-safety) | Open |
 | F5 | Info | F-string email builders bypass template autoescaping | Open |
 
-No Critical findings. No patient data exposure at rest. The two High findings (F6, F12) are recorded as resolved near-misses NM-02 and NM-03 in the Incident & Near-Miss Log. F12 remediation removed SVG upload support, added regression coverage, and confirmed through a production audit that no legacy SVG media existed. F1 remediation replaced slash-prefix checks with Django's `url_has_allowed_host_and_scheme`, constrained redirects to the current host, and requires HTTPS when the request is secure. Regression tests confirm protocol-relative, backslash-normalised, and external URLs are rejected while valid local redirects are preserved; successful signup still marks the email unconfirmed, redirects to the home page, and displays the confirmation notice. F2 remediation added the missing team and organisation invitation Markdown templates, restoring Django autoescaping before Markdown-to-HTML conversion, and explicitly escapes all dynamic values in the template-missing fallbacks. Regression tests cover both invitation types and both normal and fallback rendering paths.
+No Critical findings. No patient data exposure at rest. The two High findings (F6, F12) are recorded as resolved near-misses NM-02 and NM-03 in the Incident & Near-Miss Log. F12 remediation removed SVG upload support, added regression coverage, and confirmed through a production audit that no legacy SVG media existed. F1 remediation replaced slash-prefix checks with Django's `url_has_allowed_host_and_scheme`, constrained redirects to the current host, and requires HTTPS when the request is secure. Regression tests confirm protocol-relative, backslash-normalised, and external URLs are rejected while valid local redirects are preserved; successful signup still marks the email unconfirmed, redirects to the home page, and displays the confirmation notice. F2 remediation added the missing team and organisation invitation Markdown templates, restoring Django autoescaping before Markdown-to-HTML conversion, and explicitly escapes all dynamic values in the template-missing fallbacks. Regression tests cover both invitation types and both normal and fallback rendering paths. F7 remediation replaced the three inline `/tmp/llm_response_*.json` dump sites in `checktick_app/surveys/llm_client.py` with a single `_write_llm_debug_dump` helper that writes to `settings.BASE_DIR / "logs" / "llm"` with mode `0o600` (directory `0o700`), prunes files older than 24h on each call, omits the outgoing `messages` payload (so user prompts are never written to disk), and is blocked in production unless `LLM_DEBUG_DUMP_INSECURE=1` is also set. Regression tests in `tests/test_llm_debug_dump_security.py` cover the disabled case, the private directory and file modes, the messages-omission invariant, the production gate, the insecure-flag override, the 24h retention pruning, and an end-to-end check that `ConversationalSurveyLLM.chat` routes dumps through the helper.
 
 ### Previously Active Exceptions (Now Resolved - January 2025)
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -601,7 +601,7 @@ LOG_FILE_PATH=/var/log/checktick/app.log
 
 ##### LLM debug dumps (development only)
 
-When using the AI Assistant integration you can enable an optional debug dump that writes the full LLM HTTP response to disk for diagnosis.
+When using the AI Assistant integration you can enable an optional debug dump that writes the LLM HTTP response to disk for diagnosis.
 
 Environment variable:
 
@@ -611,8 +611,14 @@ LLM_DEBUG_DUMP=1
 
 What it does:
 
-- Writes a JSON diagnostic file to `/tmp/llm_response_<timestamp>_<id>.json` when an LLM call produces unexpected or empty streaming output.
-- The dump contains the HTTP response body, headers, status code and a small payload preview to help triage provider-specific issues.
+- Writes a JSON diagnostic file to `<BASE_DIR>/logs/llm/llm_response_<timestamp>_<id>.json` when an LLM call produces a response (or, in the streaming path, unexpected/empty output).
+- The dump contains the HTTP response body, headers, and status code to help triage provider-specific issues. The outgoing `messages` payload (which contains user prompts) is **never** written to disk.
+- Files are written with mode `0o600` and the directory with mode `0o700`, so only the application user can read them.
+- Files older than 24 hours are pruned automatically on each dump write.
+
+Production gate:
+
+- In production (`ENVIRONMENT=production`), `LLM_DEBUG_DUMP=1` alone is a no-op. You must also set `LLM_DEBUG_DUMP_INSECURE=1` to acknowledge that response payloads will be written to disk. Each write then emits a `logger.warning` so the enablement is visible in logs.
 
 When to use:
 
@@ -620,15 +626,15 @@ When to use:
 
 Risks and mitigation:
 
-- Dumps may contain user-provided text and potentially sensitive information. Do NOT enable in production or leave enabled long-term.
-- After reproducing the issue, delete dump files from `/tmp` and remove the `LLM_DEBUG_DUMP` env var.
+- Dumps may contain model output that echoes user-supplied text. Do NOT leave enabled long-term, especially in production.
+- After reproducing the issue, remove the `LLM_DEBUG_DUMP` (and `LLM_DEBUG_DUMP_INSECURE`) env vars. Stale files older than 24h are pruned automatically; you can also clear the directory manually.
 
 Quick inspect/remove commands:
 
 ```bash
-ls -1 /tmp/llm_response_*.json | tail -n 20
-jq . /tmp/llm_response_<timestamp>_<id>.json
-rm /tmp/llm_response_*.json
+ls -1 logs/llm/llm_response_*.json | tail -n 20
+jq . logs/llm/llm_response_<timestamp>_<id>.json
+rm logs/llm/llm_response_*.json
 ```
 
 Alternative diagnostics:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "checktick"
-version = "0.8.3"
+version = "0.8.4"
 description = "Secure, server-rendered survey platform for medical audit and research"
 authors = ["CheckTick Maintainers <simon@eatyourpeas.co.uk>"]
 readme = "README.md"

--- a/tests/test_llm_debug_dump_security.py
+++ b/tests/test_llm_debug_dump_security.py
@@ -14,11 +14,10 @@ Covers the three properties required by the fix:
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta
 import json
 import os
 import stat
-from datetime import datetime, timedelta
-from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -98,9 +97,7 @@ def test_dump_blocked_in_production_without_insecure_flag(
     assert not dump_dir.exists()
 
 
-def test_dump_allowed_in_production_with_insecure_flag(
-    monkeypatch, dump_dir, settings
-):
+def test_dump_allowed_in_production_with_insecure_flag(monkeypatch, dump_dir, settings):
     settings.ENVIRONMENT = "production"
     _set_env(monkeypatch, LLM_DEBUG_DUMP="1", LLM_DEBUG_DUMP_INSECURE="1")
 

--- a/tests/test_llm_debug_dump_security.py
+++ b/tests/test_llm_debug_dump_security.py
@@ -1,0 +1,167 @@
+"""
+Regression tests for the LLM debug dump hardening (security review F7).
+
+Covers the three properties required by the fix:
+
+1. Dumps are written under ``settings.BASE_DIR / "logs" / "llm"`` with mode
+   ``0o600`` (and the directory with ``0o700``), never to ``/tmp``.
+2. Dumps are gated off in production unless ``LLM_DEBUG_DUMP_INSECURE=1`` is
+   also set.
+3. The outgoing ``messages`` payload (which contains user prompts) is never
+   written to the dump file.
+4. Stale dump files older than the retention window are pruned.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from checktick_app.surveys import llm_client
+from checktick_app.surveys.llm_client import (
+    ConversationalSurveyLLM,
+    _write_llm_debug_dump,
+)
+
+
+@pytest.fixture
+def dump_dir(settings, tmp_path):
+    """Point BASE_DIR/logs/llm at a temp dir so tests don't touch the repo."""
+    settings.BASE_DIR = tmp_path
+    return tmp_path / "logs" / "llm"
+
+
+def _set_env(monkeypatch, **kwargs):
+    for k in ("LLM_DEBUG_DUMP", "LLM_DEBUG_DUMP_INSECURE"):
+        monkeypatch.delenv(k, raising=False)
+    for k, v in kwargs.items():
+        if v is None:
+            monkeypatch.delenv(k, raising=False)
+        else:
+            monkeypatch.setenv(k, v)
+
+
+def test_dump_disabled_when_env_unset(monkeypatch, dump_dir):
+    _set_env(monkeypatch)  # no flags set
+    _write_llm_debug_dump({"response": {"x": 1}})
+    assert not dump_dir.exists()
+
+
+def test_dump_written_to_private_dir_in_dev(monkeypatch, dump_dir, settings):
+    settings.ENVIRONMENT = "development"
+    _set_env(monkeypatch, LLM_DEBUG_DUMP="1")
+
+    _write_llm_debug_dump({"response": {"choices": []}})
+
+    files = list(dump_dir.glob("llm_response_*.json"))
+    assert len(files) == 1
+    # Directory and file must be owner-only.
+    assert stat.S_IMODE(dump_dir.stat().st_mode) == 0o700
+    assert stat.S_IMODE(files[0].stat().st_mode) == 0o600
+    # Must NOT be written under /tmp.
+    assert str(files[0]).startswith(str(dump_dir))
+
+
+def test_dump_omits_outgoing_messages(monkeypatch, dump_dir, settings):
+    """The dump payload must never include the outgoing messages (user prompts)."""
+    settings.ENVIRONMENT = "development"
+    _set_env(monkeypatch, LLM_DEBUG_DUMP="1")
+
+    _write_llm_debug_dump(
+        {
+            "timestamp": "20260802T120000Z",
+            "response": {"choices": [{"message": {"content": "hi"}}]},
+        }
+    )
+
+    files = list(dump_dir.glob("llm_response_*.json"))
+    assert len(files) == 1
+    written = json.loads(files[0].read_text())
+    assert "messages" not in written
+    assert "payload_preview" not in written
+    assert written["response"]["choices"][0]["message"]["content"] == "hi"
+
+
+def test_dump_blocked_in_production_without_insecure_flag(
+    monkeypatch, dump_dir, settings
+):
+    settings.ENVIRONMENT = "production"
+    _set_env(monkeypatch, LLM_DEBUG_DUMP="1")  # no INSECURE flag
+
+    _write_llm_debug_dump({"response": {"x": 1}})
+    assert not dump_dir.exists()
+
+
+def test_dump_allowed_in_production_with_insecure_flag(
+    monkeypatch, dump_dir, settings
+):
+    settings.ENVIRONMENT = "production"
+    _set_env(monkeypatch, LLM_DEBUG_DUMP="1", LLM_DEBUG_DUMP_INSECURE="1")
+
+    _write_llm_debug_dump({"response": {"x": 1}})
+    files = list(dump_dir.glob("llm_response_*.json"))
+    assert len(files) == 1
+    assert stat.S_IMODE(files[0].stat().st_mode) == 0o600
+
+
+def test_stale_dumps_are_pruned(monkeypatch, dump_dir, settings):
+    settings.ENVIRONMENT = "development"
+    _set_env(monkeypatch, LLM_DEBUG_DUMP="1")
+
+    dump_dir.mkdir(parents=True, exist_ok=True)
+    dump_dir.chmod(0o700)
+
+    # An old file (48h ago) — should be deleted.
+    old = dump_dir / "llm_response_old.json"
+    old.write_text("{}")
+    old_mtime = (datetime.utcnow() - timedelta(hours=48)).timestamp()
+    os.utime(old, (old_mtime, old_mtime))
+
+    # A recent file — should survive.
+    recent = dump_dir / "llm_response_recent.json"
+    recent.write_text("{}")
+    recent_mtime = (datetime.utcnow() - timedelta(hours=1)).timestamp()
+    os.utime(recent, (recent_mtime, recent_mtime))
+
+    _write_llm_debug_dump({"response": {"x": 1}})
+
+    assert not old.exists()
+    assert recent.exists()
+
+
+def test_chat_method_uses_safe_dump(monkeypatch, settings, tmp_path):
+    """End-to-end: ConversationalSurveyLLM.chat routes dumps through the helper."""
+    settings.BASE_DIR = tmp_path
+    settings.ENVIRONMENT = "development"
+    settings.LLM_TEMPERATURE = 0.5
+    settings.LLM_MAX_RETRIES = 1
+    settings.LLM_MODEL = "test-model"
+    _set_env(monkeypatch, LLM_DEBUG_DUMP="1")
+
+    fake_response = mock.Mock()
+    fake_response.json.return_value = {
+        "choices": [{"message": {"content": "hello world"}}]
+    }
+    fake_response.raise_for_status = mock.Mock()
+
+    with mock.patch.object(llm_client.requests, "post", return_value=fake_response):
+        client = ConversationalSurveyLLM.__new__(ConversationalSurveyLLM)
+        client.endpoint = "http://mock"
+        client.api_key = "k"
+        client.auth_type = "bearer"
+        client.timeout = 5
+        client.system_prompt = "sys"
+        result = client.chat([{"role": "user", "content": "hi"}])
+
+    assert result == "hello world"
+    files = list((tmp_path / "logs" / "llm").glob("llm_response_*.json"))
+    assert len(files) == 1
+    written = json.loads(files[0].read_text())
+    assert "messages" not in written
+    assert written["response"]["choices"][0]["message"]["content"] == "hello world"


### PR DESCRIPTION
Summary

Addresses the **F7** vulnerability from the August 2026 security review and updates all related documentation.

### Code fix — `checktick_app/surveys/llm_client.py`

Replaced the three inline dump sites (in `chat`, `chat_with_custom_system_prompt`, and `chat_stream`) with a single `_write_llm_debug_dump` helper that implements all four recommended-fix options from the security review:

1. **Private location** — writes to `settings.BASE_DIR / "logs" / "llm"` with file mode `0o600` and directory mode `0o700`, instead of world-readable `/tmp`.
2. **Messages omitted** — the outgoing `messages`/`payload_preview` payload (which contains user prompts) is never written to disk; only the response and metadata are.
3. **Retention bound** — files older than 24h are pruned on each write.
4. **Production gate** — in `ENVIRONMENT == "production"`, `LLM_DEBUG_DUMP=1` alone is a no-op; the operator must also set `LLM_DEBUG_DUMP_INSECURE=1`, and each write emits a `logger.warning` so enablement is visible.

### Regression tests — `tests/test_llm_debug_dump_security.py`

7 tests covering: dump disabled by default, private dir/file modes in dev, messages-omission invariant, production block without the insecure flag, production allow with the insecure flag, 24h retention pruning, and an end-to-end check that `ConversationalSurveyLLM.chat` routes through the helper. **All 7 pass.**

### Documentation updates

- `docs/compliance/vulnerability-patch-log.md` — F7 row marked Resolved (02/08/2026), added a remediation paragraph, bumped "Last Updated" to 02 August 2026.
- `docs/compliance/security-review-august-2026.md` — F7 marked RESOLVED in the summary table, finding heading, and remediation plan table; updated the "Priority for next patch" line; added an F7 entry to the validation/regression-test list.
- `docs/self-hosting.md` — rewrote the "LLM debug dumps" section to document the new `logs/llm/` location, `0o600`/`0o700` modes, 24h pruning, messages omission, and the `LLM_DEBUG_DUMP_INSECURE` production gate.
- `.env.selfhost` — documented `LLM_DEBUG_DUMP` and `LLM_DEBUG_DUMP_INSECURE` alongside the existing LLM config.

### Validation

- `s/lint` — passed (reformatted the two new/edited files; 0 remaining errors).
- `s/test --no-a11y --serial tests/test_llm_debug_dump_security.py` — **7 passed**.