### PR TITLE
Deploy via Northflank webhook workflow instead of restart

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -159,20 +159,16 @@ jobs:
       - name: Trigger Northflank deployment
         if: github.ref == 'refs/heads/main'
         env:
-          NF_API_TOKEN: ${{ secrets.NORTHFLANKAPIKEY }}
-          NF_PROJECT_ID: ${{ secrets.NORTHFLANK_PROJECT_ID }}
-          NF_SERVICE_ID: ${{ secrets.NORTHFLANK_SERVICE_ID }}
+          NF_WEBHOOK_URL: ${{ secrets.NORTHFLANK_WEBHOOK_URL }}
+          IMAGE_TAG: ${{ steps.app_version.outputs.version }}
         run: |
-          if [ -n "$NF_API_TOKEN" ] && [ -n "$NF_PROJECT_ID" ] && [ -n "$NF_SERVICE_ID" ]; then
-            echo "Triggering Northflank service restart..."
-            curl -X POST "https://api.northflank.com/v1/projects/${NF_PROJECT_ID}/services/${NF_SERVICE_ID}/restart" \
-              -H "Authorization: Bearer ${NF_API_TOKEN}" \
-              -H "Content-Type: application/json" \
-              && echo "✓ Service restart triggered - will pull latest image from GHCR" \
-              || echo "⚠️ Restart request failed but continuing..."
+          if [ -n "$NF_WEBHOOK_URL" ]; then
+            echo "Triggering Northflank workflow 'checktick-deployment' for ${IMAGE_TAG}..."
+            curl -fsS -X POST "${NF_WEBHOOK_URL}?IMAGE_TAG=${IMAGE_TAG}"
+            echo "✓ Northflank deployment workflow triggered for ${IMAGE_TAG}"
           else
-            echo "⊘ Northflank credentials not configured, skipping deployment trigger"
-            echo "   Required secrets: NORTHFLANK_API_TOKEN, NORTHFLANK_PROJECT_ID, NORTHFLANK_SERVICE_ID"
+            echo "⊘ NORTHFLANK_WEBHOOK_URL not configured, skipping deployment trigger"
+            echo "   Required secret: NORTHFLANK_WEBHOOK_URL"
           fi
 
   publish-skipped:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ cp .env.selfhost .env
 docker compose -f docker-compose.registry.yml up -d
 ```
 
-**Docker Images:** [ghcr.io/eatyourpeas/checktick](https://github.com/eatyourpeas/checktick/pkgs/container/checktick)
+**Docker Images:** [ghcr.io/eatyourpeas-ltd/checktick](https://github.com/eatyourpeas-ltd/checktick/pkgs/container/checktick)
 
 **Full Documentation:** See [Self-Hosting Guides](https://checktick.uk/docs/self-hosting-quickstart/)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
  <a href="https://github.com/eatyourpeas/checktick/releases">
-  <img alt="Version" src="https://img.shields.io/badge/version-0.8.10-5fcfdd?style=flat-square">
+  <img alt="Version" src="https://img.shields.io/badge/version-0.8.11-5fcfdd?style=flat-square">
  </a>
  <a href="https://github.com/eatyourpeas/checktick/blob/main/LICENSE">
   <img alt="GitHub License" src="https://img.shields.io/github/license/eatyourpeas/checktick?style=flat-square&color=5fcfdd">

--- a/docker-compose.external-db.yml
+++ b/docker-compose.external-db.yml
@@ -15,7 +15,7 @@ version: "3.8"
 
 services:
   web:
-    image: ghcr.io/eatyourpeas/checktick:latest
+    image: ghcr.io/eatyourpeas-ltd/checktick:latest
     ports:
       - "8000:8000"
     volumes:

--- a/docker-compose.registry.yml
+++ b/docker-compose.registry.yml
@@ -13,7 +13,7 @@ version: "3.8"
 
 services:
   web:
-    image: ghcr.io/eatyourpeas/checktick:latest
+    image: ghcr.io/eatyourpeas-ltd/checktick:latest
     ports:
       - "${HOST_PORT:-8000}:8000"
     volumes:

--- a/docs/self-hosting-scheduled-tasks.md
+++ b/docs/self-hosting-scheduled-tasks.md
@@ -275,7 +275,7 @@ Northflank provides native cron job support, making this the simplest option.
 2. Click **"Add Service"** → **"Cron Job"**
 3. Configure the job:
    - **Name**: `checktick-data-governance`
-   - **Docker Image**: Use the same image as your web service (e.g., `ghcr.io/eatyourpeas/checktick:latest`)
+   - **Docker Image**: Use the same image as your web service (e.g., `ghcr.io/eatyourpeas-ltd/checktick:latest`)
    - **Schedule**: `0 2 * * *` (runs at 2 AM UTC daily)
    - **Command**: `python manage.py process_data_governance`
 
@@ -591,7 +591,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: data-governance
-              image: ghcr.io/eatyourpeas/checktick:latest
+              image: ghcr.io/eatyourpeas-ltd/checktick:latest
               command:
                 - python
                 - manage.py
@@ -648,7 +648,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: snomed-update
-              image: ghcr.io/eatyourpeas/checktick:latest
+              image: ghcr.io/eatyourpeas-ltd/checktick:latest
               command:
                 - python
                 - manage.py

--- a/docs/versioning-and-deployment.md
+++ b/docs/versioning-and-deployment.md
@@ -14,7 +14,7 @@ This guide defines how CheckTick versions are managed and when container images 
 
 ## Container Registry
 
-- Registry: `ghcr.io/eatyourpeas/checktick`
+- Registry: `ghcr.io/eatyourpeas-ltd/checktick`
 - Primary tags:
   - `latest`
   - `X.Y.Z` (full semantic version)

--- a/docs/versioning-and-deployment.md
+++ b/docs/versioning-and-deployment.md
@@ -42,7 +42,8 @@ If none of these conditions are met, publish is skipped.
 1. Bump version in `pyproject.toml` (semver).
 2. Merge PR to `main`.
 3. Publish workflow applies versioned tags to GHCR.
-4. Northflank restarts and pulls latest published image.
+4. Publish workflow calls the Northflank deployment webhook with the versioned tag.
+5. The Northflank `checktick-deployment` workflow runs the pre-deploy migration job, then deploys the versioned image with zero downtime.
 
 ## Accidental No-Bump Merges
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "checktick"
-version = "0.8.10"
+version = "0.8.11"
 description = "Secure, server-rendered survey platform for medical audit and research"
 authors = ["CheckTick Maintainers <simon@eatyourpeas.co.uk>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

Replaces the GitHub Action's direct Northflank `/restart` call with a webhook trigger to the new `checktick-deployment` workflow, which runs the pre-deploy migration job and then deploys the versioned image with zero downtime.

## Changes

- **`.github/workflows/docker-publish.yml`**: The `Trigger Northflank deployment` step now POSTs to `NORTHFLANK_WEBHOOK_URL` with `?IMAGE_TAG=<version>` (from `pyproject.toml`) instead of calling the service restart API. The step fails loudly if the webhook request fails.
- **`docs/versioning-and-deployment.md`**: Updated the release flow description to reflect the webhook-triggered deploy.
- **`pyproject.toml`**: Patch version bump (already in the branch).

## Notes

- Requires the `NORTHFLANK_WEBHOOK_URL` GitHub secret (the old `NORTHFLANKAPIKEY`, `NORTHFLANK_PROJECT_ID`, `NORTHFLANK_SERVICE_ID` secrets are no longer used and can be removed).
- The Northflank `checktick-deployment` workflow must have an `IMAGE_TAG` argument override and a Deploy image node referencing `ghcr.io/eatyourpeas-ltd/checktick:${args.IMAGE_TAG}`.